### PR TITLE
feat: add inline security group rules guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -386,12 +386,14 @@ checkov -d .
 - Use default VPC
 - Skip encryption
 - Open security groups to 0.0.0.0/0
+- Use inline `ingress`/`egress` blocks in `aws_security_group`
 
 ✅ **Do:**
 - Use AWS Secrets Manager / Parameter Store
 - Create dedicated VPCs
 - Enable encryption at rest
 - Use least-privilege security groups
+- Use separate `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` resources (or `aws_security_group_rule`)
 
 **For detailed security guidance, see:**
 - **[Security & Compliance Guide](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, state file security, compliance testing

--- a/references/security-compliance.md
+++ b/references/security-compliance.md
@@ -190,6 +190,83 @@ resource "aws_security_group_rule" "app_https" {
 }
 ```
 
+### ❌ DON'T: Use Inline Security Group Rules
+
+```hcl
+# BAD: Inline ingress/egress blocks
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {  # ❌ Inline rules cause issues
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  egress {  # ❌ Avoid inline rules
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+```
+
+### ✅ DO: Use Separate Security Group Rule Resources
+
+**Preferred (AWS provider v5+):** Use `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule`:
+
+```hcl
+# Best: Modern individual rule resources (AWS provider v5+)
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  # No inline rules - managed separately
+}
+
+resource "aws_vpc_security_group_ingress_rule" "web_https" {
+  security_group_id = aws_security_group.web.id
+  cidr_ipv4         = "10.0.0.0/16"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "web_all" {
+  security_group_id = aws_security_group.web.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+```
+
+**Also acceptable:** `aws_security_group_rule` (older but still supported):
+
+```hcl
+resource "aws_security_group_rule" "web_https_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/16"]
+  security_group_id = aws_security_group.web.id
+}
+```
+
+**Why avoid inline rules:**
+
+| Issue | Inline Rules | Separate Resources |
+|-------|--------------|-------------------|
+| Rule changes | Recreates entire SG (downtime) | Updates only the rule |
+| Mixing approaches | Conflicts and overwrites | N/A - consistent pattern |
+| Dynamic rules | Limited `for_each` support | Full `for_each` support |
+| State management | Rules buried in SG state | Each rule tracked separately |
+| Conditional rules | Complex nested dynamics | Simple `count` or `for_each` |
+
 ---
 
 ## Compliance Testing

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -155,6 +155,7 @@ resource "aws_security_group" "web" {
 ### Success Criteria
 - [ ] Agent flags public S3 bucket as security risk
 - [ ] Agent flags wide-open security group
+- [ ] Agent flags inline `ingress`/`egress` blocks (should use separate rule resources)
 - [ ] Agent recommends security scanning tools (trivy/checkov)
 - [ ] Agent provides secure alternatives
 - [ ] Agent doesn't stop at "syntax correct"


### PR DESCRIPTION
 Summary

  - Add guidance to avoid inline ingress/egress blocks in aws_security_group resources
  - Recommend separate aws_vpc_security_group_ingress_rule / aws_vpc_security_group_egress_rule resources (AWS provider v5+)
  - Include comparison table explaining why inline rules cause issues (SG recreation, state management, for_each support)
  - Update baseline test Scenario 3 with new success criterion

  Files Changed

  - SKILL.md — Added bullet points to Don't/Do security checklist
  - references/security-compliance.md — Added detailed examples, comparison table, and rationale
  - tests/baseline-scenarios.md — Added success criterion for inline rule detection

  Testing Evidence

  Scenario Tested

  Scenario 3: Security Scanning Omission (tests/baseline-scenarios.md)

  Baseline (WITHOUT changes — marketplace plugin v1.6.0)

  - ✅ Flagged public S3 bucket
  - ✅ Flagged wide-open security group
  - ❌ Did NOT flag inline ingress/egress blocks
  - ❌ Suggested fix using inline blocks (perpetuated anti-pattern)

  Compliance (WITH changes — local skill with updates)

  - ✅ Flagged public S3 bucket
  - ✅ Flagged wide-open security group
  - ✅ Flagged inline ingress/egress blocks as a distinct issue
  - ✅ Recommended aws_vpc_security_group_ingress_rule as replacement
  - ✅ Explained conflict/modularity rationale

  Key Behavioral Change

  Without the skill, the agent perpetuated the inline anti-pattern in its own fix suggestion. With the skill, it identified inline rules as a separate issue and
  recommended modern separate rule resources.

  Testing Checklist

  - Identified affected scenarios from tests/baseline-scenarios.md
  - Ran baseline WITHOUT changes (documented above)
  - Applied changes
  - Ran compliance WITH changes (documented above)
  - Verified behavior improvement
  - No new rationalizations discovered