### PR TITLE
docs: add cross-host install via agent-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This plugin is distributed via Claude Code marketplace using `.claude-plugin/mar
 npx -y agent-add --skill 'https://github.com/antonbabenko/terraform-skill'
 ```
 
-Supports Claude Code, Cursor, Windsurf, and [15+ more hosts](https://github.com/pea3nut/agent-get). Requires [Node.js](https://nodejs.org/) 18+.
+Supports Claude Code, Cursor, Windsurf, and [15+ more hosts](https://github.com/pea3nut/agent-add). Requires [Node.js](https://nodejs.org/) 18+.
 
 
 ### Manual Installation

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ This plugin is distributed via Claude Code marketplace using `.claude-plugin/mar
 /plugin install terraform-skill@antonbabenko
 ```
 
+### Any AI Host (via agent-add)
+
+```bash
+npx -y agent-add --skill 'https://github.com/antonbabenko/terraform-skill'
+```
+
+Supports Claude Code, Cursor, Windsurf, and [15+ more hosts](https://github.com/pea3nut/agent-get). Requires [Node.js](https://nodejs.org/) 18+.
+
+
 ### Manual Installation
 
 ```bash


### PR DESCRIPTION
## Summary

Adds [agent-add](https://github.com/pea3nut/agent-get) as an installation option alongside the existing Claude Code marketplace and manual git clone methods. This lets users install the skill to any supported AI host (Cursor, Windsurf, and 15+ more) with a single command.

## What changed

- Added a "Any AI Host (via agent-add)" subsection in the Installation section, between "Claude Code (Recommended)" and "Manual Installation"

This is a docs-only change.