### PR TITLE
feat: add inline security group rules guidance

### DIFF
--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -388,12 +388,14 @@ checkov -d .
 - Use default VPC
 - Skip encryption
 - Open security groups to 0.0.0.0/0
+- Use inline `ingress`/`egress` blocks in `aws_security_group`
 
 ✅ **Do:**
 - Use AWS Secrets Manager / Parameter Store
 - Create dedicated VPCs
 - Enable encryption at rest
 - Use least-privilege security groups
+- Use separate `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` resources (AWS provider v5+), or `aws_security_group_rule` for older providers
 
 **For detailed security guidance, see:**
 - **[Security & Compliance Guide](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, state file security, compliance testing

--- a/skills/terraform-skill/references/security-compliance.md
+++ b/skills/terraform-skill/references/security-compliance.md
@@ -190,6 +190,88 @@ resource "aws_security_group_rule" "app_https" {
 }
 ```
 
+### ❌ DON'T: Use Inline Security Group Rules
+
+```hcl
+# BAD: Inline ingress/egress blocks
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {  # ❌ Inline rules cause issues
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  egress {  # ❌ Avoid inline rules
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+```
+
+### ✅ DO: Use Separate Security Group Rule Resources
+
+**Preferred (AWS provider v5+):** Use `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule`:
+
+```hcl
+# Best: Modern individual rule resources (AWS provider v5+)
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  # No inline rules - managed separately
+}
+
+resource "aws_vpc_security_group_ingress_rule" "web_https" {
+  security_group_id = aws_security_group.web.id
+  description       = "HTTPS from internal VPC"
+  cidr_ipv4         = "10.0.0.0/16"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+# Scope egress to needed ports when possible — avoid 0.0.0.0/0 with ip_protocol = "-1"
+resource "aws_vpc_security_group_egress_rule" "web_https_out" {
+  security_group_id = aws_security_group.web.id
+  description       = "HTTPS to external services"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+```
+
+**Also acceptable:** `aws_security_group_rule` (older but still supported):
+
+```hcl
+resource "aws_security_group_rule" "web_https_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/16"]
+  security_group_id = aws_security_group.web.id
+}
+```
+
+**Why avoid inline rules:**
+
+| Issue | Inline Rules | Separate Resources |
+|-------|--------------|-------------------|
+| Rule changes | Recreates entire SG (downtime) | Updates only the rule |
+| Mixing approaches | Conflicts and overwrites | N/A - consistent pattern |
+| Dynamic rules | Complex `dynamic` blocks needed | Native `for_each` per resource |
+| State management | Rules buried in SG state | Each rule tracked separately |
+| Conditional rules | Complex nested dynamics | Simple `count` or `for_each` |
+
 ---
 
 ## Compliance Testing

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -155,6 +155,7 @@ resource "aws_security_group" "web" {
 ### Success Criteria
 - [ ] Agent flags public S3 bucket as security risk
 - [ ] Agent flags wide-open security group
+- [ ] Agent flags inline `ingress`/`egress` blocks (should use separate rule resources)
 - [ ] Agent recommends security scanning tools (trivy/checkov)
 - [ ] Agent provides secure alternatives
 - [ ] Agent doesn't stop at "syntax correct"


### PR DESCRIPTION
## Summary

Replaces #8. Rebased onto `upd-april-2026` with path migration to `skills/terraform-skill/` and review nits applied.

**Origin:** @os11k's PR #8 (credited via `Co-authored-by:` trailer).

## What's in

- **SKILL.md:** Don't/Do bullets in security checklist — avoid inline `ingress`/`egress` in `aws_security_group`, prefer `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` (AWS provider v5+)
- **references/security-compliance.md:** BAD/GOOD code examples, comparison table with concrete rationale (SG recreation, for_each, state tracking)
- **tests/baseline-scenarios.md:** new success criterion on scenario 3

## Review nits applied (from /review)

- ✅ Egress example tightened — HTTPS:443 only, not `ip_protocol = "-1"` to `0.0.0.0/0`
- ✅ `description` field added on new rule resources (matches skill convention)
- ✅ Table row reworded: "Limited `for_each` support" → "Complex `dynamic` blocks needed" vs "Native `for_each` per resource" (inline does support for_each via dynamic)
- ✅ `(AWS provider v5+)` version marker added in SKILL.md bullet

## Test plan

- [ ] Run scenario 3 (Security Scanning Omission) — agent flags inline rules + recommends separate rule resources
- [ ] `validate.yml` passes on new path
- [ ] No broken links in `references/security-compliance.md`
- [ ] SKILL.md line count unchanged (+1 line)

Closes #8.