### PR TITLE
feat: restructure skill around failure-mode diagnosis + LLM guards

### DIFF
--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -9,593 +9,267 @@ metadata:
 
 # Terraform Skill for Claude
 
-Comprehensive Terraform and OpenTofu guidance covering testing, modules, CI/CD, and production patterns. Based on terraform-best-practices.com and enterprise experience.
+Diagnose-first guidance for Terraform and OpenTofu. Core file is a workflow; depth lives in references loaded on demand.
+
+## Response Contract
+
+Every Terraform/OpenTofu response must include:
+
+1. **Assumptions & version floor** — runtime (`terraform` or `tofu`), exact version, providers, state backend, execution path (local/CI/Cloud/Atlantis), environment criticality. State assumptions explicitly if the user did not provide them.
+2. **Risk category addressed** — one or more of: identity churn, secret exposure, blast radius, CI drift, compliance gaps, state corruption, provider upgrade risk, testing blind spots.
+3. **Chosen remediation & tradeoffs** — what was chosen, what was traded off, why.
+4. **Validation plan** — exact commands (`fmt -check`, `validate`, `plan -out`, policy check) tailored to runtime and risk tier.
+5. **Rollback notes** — for any destructive or state-mutating change: how to undo, what evidence to keep.
+
+Never recommend direct production apply without a reviewed plan artifact and approval.
+
+## Workflow
+
+1. **Capture execution context** — runtime+version, provider(s), backend, execution path, environment criticality.
+2. **Diagnose failure mode(s)** using the routing table below. If intent spans categories, load both references.
+3. **Load only the matching reference file(s)** — do not preload depth the task does not need.
+4. **Propose fix with risk controls** — why this addresses the mode, what could still go wrong, guardrails (tests/approvals/rollback).
+5. **Generate artifacts** — HCL, migration blocks (`moved`, `import`), CI changes, policy rules.
+6. **Validate before finalizing** — run validation commands tailored to risk tier.
+7. **Emit the Response Contract** at the end.
+
+## Diagnose Before You Generate
+
+| Failure category | Symptoms | Primary references |
+|------------------|----------|--------------------|
+| **Identity churn** | Resource addresses shift after refactor, `count` index churn, missing `moved` blocks | [Code Patterns: count vs for_each](references/code-patterns.md#count-vs-for_each-deep-dive), [Code Patterns: moved blocks](references/code-patterns.md#moved-blocks-terraform-11), [Code Patterns: LLM mistakes](references/code-patterns.md#llm-mistake-checklist--code-patterns) |
+| **Secret exposure** | Secrets in defaults, state, logs, CI artifacts | [Security & Compliance](references/security-compliance.md), [Code Patterns: write-only](references/code-patterns.md#write-only-arguments-terraform-111), [State Management](references/state-management.md) |
+| **Blast radius** | Oversized stacks, shared prod/non-prod state, unsafe applies | [State Management](references/state-management.md), [Module Patterns](references/module-patterns.md) |
+| **CI drift** | Local plan ≠ CI plan, apply without reviewed artifact, unpinned versions | [CI/CD Workflows](references/ci-cd-workflows.md), [Code Patterns: versions](references/code-patterns.md#version-management) |
+| **Compliance gaps** | Missing policy stage, no approval model, no evidence retention | [Security & Compliance](references/security-compliance.md), [CI/CD Workflows](references/ci-cd-workflows.md) |
+| **Testing blind spots** | Plan-only validation of computed values, set-type indexing, mock/real confusion | [Testing Frameworks](references/testing-frameworks.md) |
+| **State corruption / recovery** | Stuck lock, backend migration, drift reconciliation | [State Management](references/state-management.md) |
+| **Provider upgrade risk** | Breaking-change provider bump, unpinned modules | [Code Patterns: versions](references/code-patterns.md#version-management), [Module Patterns](references/module-patterns.md) |
 
 ## When to Use This Skill
 
-**Activate this skill when:**
-- Creating new Terraform or OpenTofu configurations or modules
-- Setting up testing infrastructure for IaC code
-- Deciding between testing approaches (validate, plan, frameworks)
-- Structuring multi-environment deployments
-- Implementing CI/CD for infrastructure-as-code
-- Reviewing or refactoring existing Terraform/OpenTofu projects
-- Choosing between module patterns or state management approaches
-- Configuring remote state backends and state locking
-- Migrating state between backends or troubleshooting state issues
+**Activate when:** creating or reviewing Terraform/OpenTofu configurations or modules, setting up or debugging tests, structuring multi-environment deployments, implementing IaC CI/CD, choosing module patterns or state organization, configuring or migrating remote state backends.
 
-**Don't use this skill for:**
-- Basic Terraform/OpenTofu syntax questions (Claude knows this)
-- Provider-specific API reference (link to docs instead)
-- Cloud platform questions unrelated to Terraform/OpenTofu
+**Don't use for:** basic HCL syntax questions Claude already knows, provider API reference (link to docs), cloud-platform questions unrelated to Terraform/OpenTofu.
 
 ## Core Principles
 
-### 1. Code Structure Philosophy
-
-**Module Hierarchy:**
+### Module Hierarchy
 
 | Type | When to Use | Scope |
 |------|-------------|-------|
-| **Resource Module** | Single logical group of connected resources | VPC + subnets, Security group + rules |
-| **Infrastructure Module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account |
+| **Resource module** | Single logical group of connected resources | VPC + subnets, SG + rules |
+| **Infrastructure module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account |
 | **Composition** | Complete infrastructure | Spans multiple regions/accounts |
 
-**Hierarchy:** Resource → Resource Module → Infrastructure Module → Composition
+Flow: resource → resource module → infrastructure module → composition.
 
-**Directory Structure:**
+### Directory Layout
+
 ```
-environments/        # Environment-specific configurations
-├── prod/
-├── staging/
-└── dev/
-
-modules/            # Reusable modules
-├── networking/
-├── compute/
-└── data/
-
-examples/           # Module usage examples (also serve as tests)
-├── complete/
-└── minimal/
+environments/   # prod/ staging/ dev/  — per-env configurations
+modules/        # networking/ compute/ data/ — reusable modules
+examples/       # minimal/ complete/ — docs + integration fixtures
 ```
 
-**Key principle from terraform-best-practices.com:**
-- Separate **environments** (prod, staging) from **modules** (reusable components)
-- Use **examples/** as both documentation and integration test fixtures
-- Keep modules small and focused (single responsibility)
+Separate **environments** from **modules**. Use `examples/` as both documentation and test fixtures. Keep modules small and single-responsibility.
 
-**For detailed module architecture, see:** [Code Patterns: Module Types & Hierarchy](references/code-patterns.md)
+See [Module Patterns](references/module-patterns.md) for architecture principles, naming conventions, variable/output contracts.
 
-### 2. Naming Conventions
+### Naming Conventions (summary)
 
-**Resources:**
-```hcl
-# Good: Descriptive, contextual
-resource "aws_instance" "web_server" { }
-resource "aws_s3_bucket" "application_logs" { }
+- Descriptive resource names (`aws_instance.web_server`, not `aws_instance.main`)
+- Reserve `this` for genuine singleton resources only
+- Prefix variables with context (`vpc_cidr_block`, not `cidr`)
+- Standard files: `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`
 
-# Good: "this" for singleton resources (only one of that type)
-resource "aws_vpc" "this" { }
-resource "aws_security_group" "this" { }
+See [Module Patterns: Variable Naming](references/module-patterns.md) and [Code Patterns: Block Ordering](references/code-patterns.md#block-ordering--structure) for examples.
 
-# Avoid: Generic names for non-singletons
-resource "aws_instance" "main" { }
-resource "aws_s3_bucket" "bucket" { }
-```
+### Block Ordering (summary)
 
-**Singleton Resources:**
+Resource blocks: `count`/`for_each` first → arguments → `tags` → `depends_on` → `lifecycle`.
+Variable blocks: `description` → `type` → `default` → `validation` → `nullable` → `sensitive`.
 
-Use `"this"` when your module creates only one resource of that type:
+See [Code Patterns: Block Ordering & Structure](references/code-patterns.md#block-ordering--structure) for the full rules and examples.
 
-✅ DO:
-```hcl
-resource "aws_vpc" "this" {}           # Module creates one VPC
-resource "aws_security_group" "this" {}  # Module creates one SG
-```
-
-❌ DON'T use "this" for multiple resources:
-```hcl
-resource "aws_subnet" "this" {}  # If creating multiple subnets
-```
-
-Use descriptive names when creating multiple resources of the same type.
-
-**Variables:**
-```hcl
-# Prefix with context when needed
-var.vpc_cidr_block          # Not just "cidr"
-var.database_instance_class # Not just "instance_class"
-```
-
-**Files:**
-- `main.tf` - Primary resources
-- `variables.tf` - Input variables
-- `outputs.tf` - Output values
-- `versions.tf` - Provider versions
-- `data.tf` - Data sources (optional)
-
-## Testing Strategy Framework
+## Testing Strategy
 
 ### Decision Matrix: Which Testing Approach?
 
-| Your Situation | Recommended Approach | Tools | Cost |
-|----------------|---------------------|-------|------|
-| **Quick syntax check** | Static analysis | `terraform validate`, `fmt` | Free |
-| **Pre-commit validation** | Static + lint | `validate`, `tflint`, `trivy`, `checkov` | Free |
-| **Terraform 1.6+, simple logic** | Native test framework | Built-in `terraform test` | Free-Low |
-| **Pre-1.6, or Go expertise** | Integration testing | Terratest | Low-Med |
-| **Security/compliance focus** | Policy as code | OPA, Sentinel | Free |
-| **Cost-sensitive workflow** | Mock providers (1.7+) | Native tests + mocking | Free |
-| **Multi-cloud, complex** | Full integration | Terratest + real infra | Med-High |
+| Situation | Approach | Tools | Cost |
+|-----------|----------|-------|------|
+| Quick syntax check | Static analysis | `validate`, `fmt` | Free |
+| Pre-commit validation | Static + lint | `validate`, `tflint`, `trivy`, `checkov` | Free |
+| Terraform 1.6+, simple logic | Native test framework | `terraform test` | Free-Low |
+| Pre-1.6, or Go expertise | Integration testing | Terratest | Low-Med |
+| Security/compliance focus | Policy as code | OPA, Sentinel | Free |
+| Cost-sensitive workflow | Mock providers (1.7+) | Native tests + mocks | Free |
+| Multi-cloud, complex | Full integration | Terratest + real infra | Med-High |
 
-### Testing Pyramid for Infrastructure
+### Native Test Rules (1.6+)
 
-```
-        /\
-       /  \          End-to-End Tests (Expensive)
-      /____\         - Full environment deployment
-     /      \        - Production-like setup
-    /________\
-   /          \      Integration Tests (Moderate)
-  /____________\     - Module testing in isolation
- /              \    - Real resources in test account
-/________________\   Static Analysis (Cheap)
-                     - validate, fmt, lint
-                     - Security scanning
-```
+Before writing test code: validate resource schemas via Terraform MCP so assertions target real attributes.
 
-### Native Test Best Practices (1.6+)
+- `command = plan` — fast, for input-derived values only
+- `command = apply` — required for **computed values** (ARNs, generated names) and **set-type nested blocks**
+- Set-type blocks cannot be indexed with `[0]` — use `for` expressions or materialize via `command = apply`
+- Common set types: S3 encryption rules, lifecycle transitions, IAM policy statements
 
-**Before generating test code:**
+See [Testing Frameworks](references/testing-frameworks.md) for static-analysis pipelines, native-test patterns, Terratest integration, mock providers, and the full LLM-mistake checklist.
 
-1. **Validate schemas with Terraform MCP:**
-   ```
-   Search provider docs → Get resource schema → Identify block types
-   ```
-
-2. **Choose correct command mode:**
-   - `command = plan` - Fast, for input validation
-   - `command = apply` - Required for computed values and set-type blocks
-
-3. **Handle set-type blocks correctly:**
-   - Cannot index with `[0]`
-   - Use `for` expressions to iterate
-   - Or use `command = apply` to materialize
-
-**Common patterns:**
-- S3 encryption rules: **set** (use for expressions)
-- Lifecycle transitions: **set** (use for expressions)
-- IAM policy statements: **set** (use for expressions)
-
-**For detailed testing guides, see:**
-- **[Testing Frameworks Guide](references/testing-frameworks.md)** - Deep dive into static analysis, native tests, and Terratest
-- **[Quick Reference](references/quick-reference.md#testing-approach-selection)** - Decision flowchart and command cheat sheet
-
-## Code Structure Standards
-
-### Resource Block Ordering
-
-**Strict ordering for consistency:**
-1. `count` or `for_each` FIRST (blank line after)
-2. Other arguments
-3. `tags` as last real argument
-4. `depends_on` after tags (if needed)
-5. `lifecycle` at the very end (if needed)
-
-```hcl
-# ✅ GOOD - Correct ordering
-resource "aws_nat_gateway" "this" {
-  count = var.create_nat_gateway ? 1 : 0
-
-  allocation_id = aws_eip.this[0].id
-  subnet_id     = aws_subnet.public[0].id
-
-  tags = {
-    Name = "${var.name}-nat"
-  }
-
-  depends_on = [aws_internet_gateway.this]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-```
-
-### Variable Block Ordering
-
-1. `description` (ALWAYS required)
-2. `type`
-3. `default`
-4. `validation`
-5. `nullable` (when setting to false)
-
-```hcl
-variable "environment" {
-  description = "Environment name for resource tagging"
-  type        = string
-  default     = "dev"
-
-  validation {
-    condition     = contains(["dev", "staging", "prod"], var.environment)
-    error_message = "Environment must be one of: dev, staging, prod."
-  }
-
-  nullable = false
-}
-```
-
-**For complete structure guidelines, see:** [Code Patterns: Block Ordering & Structure](references/code-patterns.md#block-ordering--structure)
-
-## Count vs For_Each: When to Use Each
-
-### Quick Decision Guide
+## Count vs For_Each — Quick Rule
 
 | Scenario | Use | Why |
 |----------|-----|-----|
-| Boolean condition (create or don't) | `count = condition ? 1 : 0` | Simple on/off toggle |
-| Simple numeric replication | `count = 3` | Fixed number of identical resources |
-| Items may be reordered/removed | `for_each = toset(list)` | Stable resource addresses |
-| Reference by key | `for_each = map` | Named access to resources |
-| Multiple named resources | `for_each` | Better maintainability |
+| Boolean condition (create / don't) | `count = condition ? 1 : 0` | Optional singleton toggle |
+| Items may be reordered or removed | `for_each = toset(list)` | Stable resource addresses |
+| Reference by key | `for_each = map` | Named access |
+| Multiple named resources | `for_each` | Better identity stability |
 
-### Common Patterns
-
-**Boolean conditions:**
-```hcl
-# ✅ GOOD - Boolean condition
-resource "aws_nat_gateway" "this" {
-  count = var.create_nat_gateway ? 1 : 0
-  # ...
-}
-```
-
-**Stable addressing with for_each:**
-```hcl
-# ✅ GOOD - Removing "us-east-1b" only affects that subnet
-resource "aws_subnet" "private" {
-  for_each = toset(var.availability_zones)
-
-  availability_zone = each.key
-  # ...
-}
-
-# ❌ BAD - Removing middle AZ recreates all subsequent subnets
-resource "aws_subnet" "private" {
-  count = length(var.availability_zones)
-
-  availability_zone = var.availability_zones[count.index]
-  # ...
-}
-```
-
-**For migration guides and detailed examples, see:** [Code Patterns: Count vs For_Each](references/code-patterns.md#count-vs-for_each-deep-dive)
+**Never** use list index as long-lived identity — removing a middle element reshuffles every address after it. For the decision matrix, safe migration playbook, `moved` block patterns, and known-at-plan failure cases, see [Code Patterns: count vs for_each](references/code-patterns.md#count-vs-for_each-deep-dive).
 
 ## Locals for Dependency Management
 
-**Use locals to ensure correct resource deletion order:**
+Using `try()` in a local to prefer a conditional resource's attribute over its parent is a specialized but high-value pattern — it forces correct deletion order without explicit `depends_on`. Common use: VPC + secondary CIDR associations + subnets.
 
-```hcl
-# Problem: Subnets might be deleted after CIDR blocks, causing errors
-# Solution: Use try() in locals to hint deletion order
-
-locals {
-  # References secondary CIDR first, falling back to VPC
-  # Forces Terraform to delete subnets before CIDR association
-  vpc_id = try(
-    aws_vpc_ipv4_cidr_block_association.this[0].vpc_id,
-    aws_vpc.this.id,
-    ""
-  )
-}
-
-resource "aws_vpc" "this" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_vpc_ipv4_cidr_block_association" "this" {
-  count = var.add_secondary_cidr ? 1 : 0
-
-  vpc_id     = aws_vpc.this.id
-  cidr_block = "10.1.0.0/16"
-}
-
-resource "aws_subnet" "public" {
-  vpc_id     = local.vpc_id  # Uses local, not direct reference
-  cidr_block = "10.1.0.0/24"
-}
-```
-
-**Why this matters:**
-- Prevents deletion errors when destroying infrastructure
-- Ensures correct dependency order without explicit `depends_on`
-- Particularly useful for VPC configurations with secondary CIDR blocks
-
-**For detailed examples, see:** [Code Patterns: Locals for Dependency Management](references/code-patterns.md#locals-for-dependency-management)
+See [Code Patterns: Locals for Dependency Management](references/code-patterns.md#locals-for-dependency-management) for the full pattern and worked example.
 
 ## Module Development
 
-### Standard Module Structure
+Standard layout:
 
 ```
 my-module/
-├── README.md           # Usage documentation
-├── main.tf             # Primary resources
-├── variables.tf        # Input variables with descriptions
-├── outputs.tf          # Output values
-├── versions.tf         # Provider version constraints
+├── README.md       # Usage documentation
+├── main.tf         # Primary resources
+├── variables.tf    # Typed inputs with descriptions
+├── outputs.tf      # Output values
+├── versions.tf     # required_version + required_providers
 ├── examples/
-│   ├── minimal/        # Minimal working example
-│   └── complete/       # Full-featured example
-└── tests/              # Test files
-    └── module_test.tftest.hcl  # Or .go
+│   ├── minimal/
+│   └── complete/
+└── tests/
+    └── module_test.tftest.hcl   # or Go for Terratest
 ```
 
-### Best Practices Summary
+**Variable contracts**: always `description`, always explicit `type`, use `validation` for complex constraints, use `sensitive = true` for secrets, prefer `optional()` with typed defaults (1.3+) over untyped `map(any)`.
 
-**Variables:**
-- ✅ Always include `description`
-- ✅ Use explicit `type` constraints
-- ✅ Provide sensible `default` values where appropriate
-- ✅ Add `validation` blocks for complex constraints
-- ✅ Use `sensitive = true` for secrets
+**Output contracts**: always `description`, mark sensitive outputs, expose stable subsets (not whole provider objects).
 
-**Outputs:**
-- ✅ Always include `description`
-- ✅ Mark sensitive outputs with `sensitive = true`
-- ✅ Consider returning objects for related values
-- ✅ Document what consumers should do with each output
+See [Module Patterns](references/module-patterns.md) for the full contract patterns, module release checklist, and LLM-mistake checklist.
 
-**For detailed module patterns, see:**
-- **[Module Patterns Guide](references/module-patterns.md)** - Variable best practices, output design, ✅ DO vs ❌ DON'T patterns
-- **[Quick Reference](references/quick-reference.md#common-patterns)** - Resource naming, variable naming, file organization
+## CI/CD
 
-## CI/CD Integration
+Pipeline stages: **validate** → **test** → **plan** → **apply** (with environment protection).
 
-### Recommended Workflow Stages
+Cost control: mock providers on PR validation, real-cloud integration only on main or scheduled, tag test resources, auto-cleanup.
 
-1. **Validate** - Format check + syntax validation + linting
-2. **Test** - Run automated tests (native or Terratest)
-3. **Plan** - Generate and review execution plan
-4. **Apply** - Execute changes (with approvals for production)
+Drift prevention: pin runtime and providers, commit `.terraform.lock.hcl`, apply the **reviewed plan artifact** from the plan stage (do not re-run `plan` inside the apply job), run policy/security stage on every path to apply.
 
-### Cost Optimization Strategy
-
-1. **Use mocking for PR validation** (free)
-2. **Run integration tests only on main branch** (controlled cost)
-3. **Implement auto-cleanup** (prevent orphaned resources)
-4. **Tag all test resources** (track spending)
-
-**For complete CI/CD templates, see:**
-- **[CI/CD Workflows Guide](references/ci-cd-workflows.md)** - GitHub Actions, GitLab CI, Atlantis integration, cost optimization
-- **[Quick Reference](references/quick-reference.md#troubleshooting-guide)** - Common CI/CD issues and solutions
+See [CI/CD Workflows](references/ci-cd-workflows.md) for GitHub Actions, GitLab CI, and Atlantis templates plus the LLM-mistake checklist.
 
 ## Security & Compliance
 
-### Essential Security Checks
+**Essential checks:**
 
 ```bash
-# Static security scanning
 trivy config .
 checkov -d .
 ```
 
-### Common Issues to Avoid
+**Don't:** store secrets in variables or `.tfvars`, use default VPC, skip encryption, open security groups to `0.0.0.0/0`, use inline `ingress`/`egress` blocks in `aws_security_group`.
 
-❌ **Don't:**
-- Store secrets in variables
-- Use default VPC
-- Skip encryption
-- Open security groups to 0.0.0.0/0
-- Use inline `ingress`/`egress` blocks in `aws_security_group`
+**Do:** source secrets from AWS Secrets Manager / Parameter Store or use `write_only` arguments on 1.11+, create dedicated VPCs, enforce encryption at rest and TLS, least-privilege SGs, use separate `aws_vpc_security_group_{ingress,egress}_rule` resources (AWS provider v5+).
 
-✅ **Do:**
-- Use AWS Secrets Manager / Parameter Store
-- Create dedicated VPCs
-- Enable encryption at rest
-- Use least-privilege security groups
-- Use separate `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` resources (AWS provider v5+), or `aws_security_group_rule` for older providers
+Marking a variable `sensitive = true` masks display only — the value still lives in state. Use `write_only` / `*_wo` on 1.11+, or keep secret material out of Terraform entirely via runtime lookups.
 
-**For detailed security guidance, see:**
-- **[Security & Compliance Guide](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, state file security, compliance testing
+See [Security & Compliance](references/security-compliance.md) for trivy/checkov pipelines, state-file hardening, compliance mappings, and the LLM-mistake checklist.
 
 ## State Management
 
-### Critical Principle: Never Use Local State in Production
+**Never use local state in teams or production.** Remote backends provide automatic locking, encryption, versioning, audit logging, and safe collaboration.
 
-**Always use remote backends for:**
-- ✅ Team collaboration with automatic locking
-- ✅ State versioning and backup
-- ✅ Encryption at rest and in transit
-- ✅ Audit logging
+### Minimum Viable Backend (AWS S3, 1.11+)
 
-### Remote Backend Quick Setup
-
-**AWS S3 (Recommended):**
-
-*Terraform 1.11+ (Recommended):*
 ```hcl
-# backend.tf - Native S3 locking, no DynamoDB needed
 terraform {
   backend "s3" {
-    bucket       = "my-terraform-state"
-    key          = "prod/vpc/terraform.tfstate"
-    region       = "us-east-1"
-    encrypt      = true
-    use_lock_file = true  # Native S3 locking
+    bucket        = "my-terraform-state"
+    key           = "prod/vpc/terraform.tfstate"
+    region        = "us-east-1"
+    encrypt       = true
+    use_lockfile  = true   # Native S3 locking, 1.11+
   }
 }
 ```
 
-*Pre-1.11 or Legacy DynamoDB locking:*
-```hcl
-# backend.tf
-terraform {
-  backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/vpc/terraform.tfstate"
-    region         = "us-east-1"
-    encrypt        = true
-    dynamodb_table = "terraform-state-lock"
-  }
-}
-```
+On Terraform < 1.11, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking — see the State Management reference for syntax.
 
-**Other backends:**
-- **Azure Storage** - Built-in blob lease locking
-- **Google Cloud Storage** - Built-in object metadata locking
-- **Terraform Cloud** - Fully managed with remote execution
-
-### State Organization Patterns
+### State Organization
 
 | Pattern | Use When | Example Path |
 |---------|----------|--------------|
-| **Per Environment** | Different teams per env | `prod/terraform.tfstate`, `staging/terraform.tfstate` |
-| **Per Component** | Independent lifecycles | `prod/vpc/`, `prod/eks/`, `prod/rds/` |
-| **Hybrid** (Recommended) | Both benefits | `prod/networking/`, `prod/compute/`, `staging/networking/` |
+| **Per environment** | Different teams per env | `prod/terraform.tfstate`, `staging/...` |
+| **Per component** | Independent lifecycles | `prod/vpc/`, `prod/eks/`, `prod/rds/` |
+| **Hybrid** (recommended) | Both benefits | `prod/networking/`, `prod/compute/`, `staging/networking/` |
 
-**Decision guide:**
-- **Split state when:** Different teams, different update frequencies, >500 resources
-- **Combine state when:** Tightly coupled resources, <100 resources, same lifecycle
+Split state when: different teams, different update cadences, or >500 resources. Combine when: tightly coupled resources, <100 resources, same lifecycle.
 
-### State Security Best Practices
-
-✅ **DO:**
-- Use encryption at rest (KMS)
-- Enable state versioning
-- Restrict IAM access per environment
-- Use write-only arguments for secrets (Terraform 1.11+)
-- Reference secrets from external sources (Secrets Manager)
-- Enable audit logging
-
-❌ **DON'T:**
-- Store secrets in variables
-- Use local state for teams/production
-- Share state files via git
-- Force-unlock without verification
-- Skip backups
-
-**For comprehensive state management guidance, see:**
-- **[State Management Guide](references/state-management.md)** - Remote backends, locking, security, migration, multi-team patterns, recovery strategies
+See [State Management](references/state-management.md) for locking, migration, multi-team isolation, disaster recovery, and the LLM-mistake checklist.
 
 ## Version Management
 
-### Version Constraint Syntax
-
-```hcl
-version = "5.0.0"      # Exact (avoid - inflexible)
-version = "~> 5.0"     # Recommended: 5.0.x only
-version = ">= 5.0"     # Minimum (risky - breaking changes)
-```
-
-### Strategy by Component
-
 | Component | Strategy | Example |
 |-----------|----------|---------|
-| **Terraform** | Pin minor version | `required_version = "~> 1.9"` |
-| **Providers** | Pin major version | `version = "~> 5.0"` |
-| **Modules (prod)** | Pin exact version | `version = "5.1.2"` |
-| **Modules (dev)** | Allow patch updates | `version = "~> 5.1"` |
+| Terraform runtime | Pin minor | `required_version = "~> 1.9"` |
+| Providers | Pin major | `version = "~> 5.0"` |
+| Modules (prod) | Pin exact | `version = "5.1.2"` |
+| Modules (dev) | Allow patch | `version = "~> 5.1"` |
 
-### Update Workflow
-
-```bash
-# Lock versions initially
-terraform init              # Creates .terraform.lock.hcl
-
-# Update to latest within constraints
-terraform init -upgrade     # Updates providers
-
-# Review and test
-terraform plan
-```
-
-**For detailed version management, see:** [Code Patterns: Version Management](references/code-patterns.md#version-management)
+Commit `.terraform.lock.hcl` intentionally. Keep provider/runtime upgrades in a separate PR from functional changes. See [Code Patterns: Version Management](references/code-patterns.md#version-management) for constraint syntax and upgrade workflow.
 
 ## Modern Terraform Features (1.0+)
 
-### Feature Availability by Version
-
-| Feature | Version | Use Case |
-|---------|---------|----------|
-| `try()` function | 0.13+ | Safe fallbacks, replaces `element(concat())` |
-| `nullable = false` | 1.1+ | Prevent null values in variables |
+| Feature | Min version | Common use |
+|---------|-------------|------------|
+| `try()` | 0.13+ | Safe fallbacks, replaces `element(concat())` |
+| `nullable = false` | 1.1+ | Prevent `null` silently overriding defaults |
 | `moved` blocks | 1.1+ | Refactor without destroy/recreate |
-| `optional()` with defaults | 1.3+ | Optional object attributes |
-| Native testing | 1.6+ | Built-in test framework |
+| `optional()` with defaults | 1.3+ | Typed object attributes |
+| `import` blocks | 1.5+ | Declarative imports, reviewable in VCS |
+| `check` blocks | 1.5+ | Runtime assertions |
+| Native `terraform test` | 1.6+ | Built-in test framework |
 | Mock providers | 1.7+ | Cost-free unit testing |
-| Provider functions | 1.8+ | Provider-specific data transformation |
+| `removed` blocks | 1.7+ | Declarative resource removal |
+| Provider-defined functions | 1.8+ | Provider-specific transformations |
 | Cross-variable validation | 1.9+ | Validate relationships between variables |
-| Write-only arguments | 1.11+ | Secrets never stored in state |
+| `write_only` arguments | 1.11+ | Secrets never stored in state |
 | S3 native lock-file | 1.11+ | State locking without DynamoDB |
 
-### Quick Examples
+Before emitting a feature, verify the runtime floor. See [Code Patterns: Feature Guard Table](references/code-patterns.md#feature-guard-table--version-floor--common-llm-errors) for the full table with common LLM error patterns per feature.
 
-```hcl
-# try() - Safe fallbacks (0.13+)
-output "sg_id" {
-  value = try(aws_security_group.this[0].id, "")
-}
+## Runtime-Specific Guidance
 
-# optional() - Optional attributes with defaults (1.3+)
-variable "config" {
-  type = object({
-    name    = string
-    timeout = optional(number, 300)  # Default: 300
-  })
-}
+- **Terraform 1.0-1.5 / OpenTofu 1.0-1.5**: Terratest for integration, static analysis + plan validation only (no native tests).
+- **1.6+**: native `terraform test` / `tofu test` available — migrate simple unit tests, keep Terratest for complex integration.
+- **1.7+**: mock providers cut test cost — mock for unit tests, real runs for final integration.
+- **1.11+**: `write_only` arguments + S3 native lock are the correct default for new configurations.
+- **Terraform vs OpenTofu**: both supported. For licensing, governance, and feature delta, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference.md#terraform-vs-opentofu-comparison).
 
-# Cross-variable validation (1.9+)
-variable "environment" { type = string }
-variable "backup_days" {
-  type = number
-  validation {
-    condition     = var.environment == "prod" ? var.backup_days >= 7 : true
-    error_message = "Production requires backup_days >= 7"
-  }
-}
-```
+## Reference Files
 
-**For complete patterns and examples, see:** [Code Patterns: Modern Terraform Features](references/code-patterns.md#modern-terraform-features-10)
+Progressive disclosure — essentials here, depth on demand:
 
-## Version-Specific Guidance
-
-### Terraform 1.0-1.5
-- Use Terratest for testing
-- No native testing framework available
-- Focus on static analysis and plan validation
-
-### Terraform 1.6+ / OpenTofu 1.6+
-- **New:** Native `terraform test` / `tofu test` command
-- Consider migrating from external frameworks for simple tests
-- Keep Terratest only for complex integration tests
-
-### Terraform 1.7+ / OpenTofu 1.7+
-- **New:** Mock providers for unit testing
-- Reduce cost by mocking external dependencies
-- Use real integration tests for final validation
-
-### Terraform vs OpenTofu
-
-Both are fully supported by this skill. For licensing, governance, and feature comparison, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference.md#terraform-vs-opentofu-comparison).
-
-## Detailed Guides
-
-This skill uses **progressive disclosure** - essential information is in this main file, detailed guides are available when needed:
-
-📚 **Reference Files:**
-- **[Testing Frameworks](references/testing-frameworks.md)** - In-depth guide to static analysis, native tests, and Terratest
-- **[Module Patterns](references/module-patterns.md)** - Module structure, variable/output best practices, ✅ DO vs ❌ DON'T patterns
-- **[CI/CD Workflows](references/ci-cd-workflows.md)** - GitHub Actions, GitLab CI templates, cost optimization, automated cleanup
-- **[Security & Compliance](references/security-compliance.md)** - Trivy/Checkov integration, secrets management, compliance testing
-- **[State Management](references/state-management.md)** - Remote backends, state locking, security, migration, multi-team patterns, recovery
-- **[Quick Reference](references/quick-reference.md)** - Command cheat sheets, decision flowcharts, troubleshooting guide
-
-**How to use:** When you need detailed information on a topic, reference the appropriate guide. Claude will load it on demand to provide comprehensive guidance.
+- [Testing Frameworks](references/testing-frameworks.md) — static analysis, native tests, Terratest, mock providers
+- [Module Patterns](references/module-patterns.md) — structure, variable/output contracts, `terraform_remote_state` rules, release checklist
+- [CI/CD Workflows](references/ci-cd-workflows.md) — GitHub Actions, GitLab CI, Atlantis, cost control
+- [Security & Compliance](references/security-compliance.md) — trivy/checkov, secrets handling, compliance mappings
+- [State Management](references/state-management.md) — backends, locking, migration, multi-team, recovery
+- [Code Patterns](references/code-patterns.md) — block ordering, `count`/`for_each` deep dive, modern features, version management, locals
+- [Quick Reference](references/quick-reference.md) — command cheat sheets, flowcharts, troubleshooting
 
 ## License
 
-This skill is licensed under the **Apache License 2.0**. See the LICENSE file for full terms.
+Apache License 2.0. See LICENSE for full terms.
 
 **Copyright © 2026 Anton Babenko**

--- a/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/skills/terraform-skill/references/ci-cd-workflows.md
@@ -470,4 +470,19 @@ bucketName := fmt.Sprintf("test-bucket-%s-%s",
 
 ---
 
+## LLM Mistake Checklist — CI/CD
+
+Common model mistakes to correct before returning pipeline recommendations:
+
+- generates a pipeline with no lockfile strategy (`.terraform.lock.hcl` uncommitted or unreviewed)
+- re-runs `terraform plan` inside the apply job instead of consuming the reviewed plan artifact from the plan stage
+- omits environment protection / approval gates on production apply
+- uses unpinned provider versions, causing drift between local and CI runs
+- skips the policy/security stage despite the pipeline claiming compliance
+- grants CI long-lived static cloud credentials instead of OIDC / workload-identity federation
+- fails to restrict artifact access when `terraform show -json` results may contain sensitive plan output
+- merges provider/runtime upgrades with functional changes in the same PR
+
+---
+
 **Back to:** [Main Skill File](../SKILL.md)

--- a/skills/terraform-skill/references/code-patterns.md
+++ b/skills/terraform-skill/references/code-patterns.md
@@ -334,6 +334,29 @@ moved {
 
 ## Modern Terraform Features (1.0+)
 
+### Feature Guard Table — Version Floor & Common LLM Errors
+
+Before emitting a feature, verify the runtime floor. Each feature here is also a known hallucination surface — the error pattern column names the mistake to avoid.
+
+| Feature | Min version | Common LLM error pattern |
+|---------|-------------|--------------------------|
+| `for_each` over `count` for stable identities | 0.12+ | defaults to `count` for every collection, causing index churn |
+| `try()` function | 0.13+ | falls back to `element(concat())` legacy pattern |
+| `nullable = false` | 1.1+ | omits it, letting `null` silently override defaults |
+| `moved` blocks | 1.1+ | omitted during refactor, causing destroy/create |
+| `optional()` with defaults | 1.3+ | emits wrapper variables and loose `map(any)` contracts |
+| declarative `import` blocks | 1.5+ | recommends ad-hoc CLI `terraform import` only |
+| `check` blocks | 1.5+ | ignores runtime assertions entirely |
+| native `terraform test` | 1.6+ | treats mocked-provider tests as full integration coverage |
+| mock providers | 1.7+ | asserts computed values in `command = plan` mode |
+| `removed` blocks | 1.7+ | deletes resources with no lifecycle transition |
+| provider-defined functions | 1.8+ | overuses data sources for simple transformations |
+| cross-variable validation | 1.9+ | pushes checks into postconditions only |
+| `write_only` arguments | 1.11+ | uses `sensitive = true` and assumes state is safe |
+| S3 native lock-file | 1.11+ | recommends DynamoDB lock table even on 1.11+ |
+
+If target runtime is below a feature floor, emit the pre-floor fallback explicitly instead of silently downgrading.
+
 ### try() Function (Terraform 0.13+)
 
 **Use try() instead of element(concat()):**
@@ -403,7 +426,7 @@ database_config = {
 
 ### Moved Blocks (Terraform 1.1+)
 
-**Rename resources without destroy/recreate:**
+**Rename resources without destroy/recreate.** Omitting `moved` during a refactor is one of the most common LLM mistakes — the model renames the address and silently turns the rename into destroy/create. Always emit `moved` in the same change as the rename, then verify `terraform plan` shows a move operation, not replacement.
 
 ```hcl
 # Rename a resource
@@ -487,7 +510,7 @@ variable "backup_retention" {
 
 ### Write-Only Arguments (Terraform 1.11+)
 
-**Always use write-only arguments or external secret management:**
+**Always use write-only arguments or external secret management.** A common LLM mistake is to mark a variable `sensitive = true` and assume the value is kept out of state — it is not. `sensitive` only masks display; write-only arguments (or external secret lookups at runtime) are what actually keep material out of state. Verify on 1.11+: prefer `*_wo` arguments for credentials; on older runtimes, source secrets from a secret manager and never store them in variables or tfvars.
 
 ```hcl
 # ✅ GOOD - External secret with write-only argument
@@ -853,6 +876,24 @@ resource "aws_subnet" "public" {
 - VPC with secondary CIDR blocks
 - Resources that depend on optional configurations
 - Complex deletion order requirements
+
+---
+
+## LLM Mistake Checklist — Code Patterns
+
+Common model mistakes when generating HCL. Correct these before returning code:
+
+- defaults to `count` for every collection — prefer `for_each` with stable keys whenever identity matters
+- omits `moved` blocks during rename/refactor, silently turning the change into destroy/create
+- builds `for_each` keys from computed IDs not known until apply — planning will fail
+- uses list index as long-lived identity (`count.index`) instead of business-meaningful keys
+- marks variables `sensitive = true` and assumes the value stays out of state — on 1.11+ use `write_only` / `*_wo` arguments
+- falls back to `element(concat(...))` instead of `try()` on 0.13+
+- accepts untyped `map(any)` / `any` for long-lived module contracts instead of `optional()` with typed defaults (1.3+)
+- suggests `terraform state mv` where `moved` blocks are safer and reviewable
+- recommends ad-hoc CLI `terraform import` instead of declarative `import` blocks (1.5+)
+- emits an exact `version = "5.0.0"` pin where `~> 5.0` would be more maintainable
+- silently emits 1.11+ features (S3 native lock, `write_only`, `removed`) without checking the runtime floor
 
 ---
 

--- a/skills/terraform-skill/references/module-patterns.md
+++ b/skills/terraform-skill/references/module-patterns.md
@@ -224,15 +224,29 @@ terraform {
 }
 ```
 
-### 3. Use terraform_remote_state as Glue
+### 3. Use terraform_remote_state Sparingly — Only at True Ownership Boundaries
 
-**Pattern:** Connect compositions via remote state data sources
+**Pattern:** Connect separately-owned compositions via remote state data sources. Reserve it for genuine team/lifecycle boundaries, not as convenient glue inside a single-team stack.
 
-**Why:**
-- Loose coupling between infrastructure components
-- Teams can work independently
-- Changes to one stack don't require rebuilding others
-- Outputs from one stack become inputs to another
+**Use it when ALL of these are true:**
+- Consumer and producer are owned by **different teams** or have **different release cadences**
+- The producer's state is already split for lifecycle reasons (networking vs. compute vs. data)
+- You cannot reasonably pass the same values as module inputs
+
+**Do NOT use it when:**
+- You control both stacks and can wire via module outputs
+- You're reading values that would be better served by a cloud data source (e.g., `aws_vpc` by tag)
+- You're reaching across >2 remote states in one composition — that is a signal to reshape boundaries, not add more wiring
+
+**Common LLM mistakes:**
+- reaches for `terraform_remote_state` as default integration pattern
+- chains many `terraform_remote_state` reads, creating hidden cross-stack coupling
+- reads values that can drift at the provider level (use cloud data sources instead)
+
+**Why it works at real boundaries:**
+- Loose coupling between independently-owned stacks
+- Teams can release independently
+- Outputs from one stack become typed inputs to another
 
 **Example:**
 
@@ -542,36 +556,11 @@ output "connection_info" {
 
 ## Common Patterns
 
-### ✅ DO: Use `for_each` for Resources
+### Iteration: `for_each` vs `count`
 
-```hcl
-# Good: Maintain stable resource addresses
-resource "aws_instance" "server" {
-  for_each = toset(["web", "api", "worker"])
+Use `for_each` with stable keys whenever a collection has meaningful identity — removing or reordering an element leaves unrelated addresses untouched. Reserve `count` for optional singletons (`0` or `1`) and cases where keys cannot be known at plan time.
 
-  instance_type = "t3.micro"
-  tags = {
-    Name = each.key
-  }
-}
-```
-
-**Why?** When you remove an item from the middle, `for_each` doesn't reshuffle other resources.
-
-### ❌ DON'T: Use `count` When Order Matters
-
-```hcl
-# Bad: Removing middle item reshuffles all subsequent resources
-resource "aws_instance" "server" {
-  count = length(var.server_names)
-
-  tags = {
-    Name = var.server_names[count.index]
-  }
-}
-```
-
-**Problem:** If you remove `var.server_names[1]`, Terraform will destroy and recreate all instances after it.
+For the decision matrix, migration playbook, and known-at-plan failure patterns, see [Code Patterns: count vs for_each](code-patterns.md#count-vs-for_each-deep-dive).
 
 ### ✅ DO: Separate Root Module from Reusable Modules
 
@@ -707,24 +696,7 @@ environments/
 
 ### ❌ DON'T: Use `terraform_remote_state` Everywhere
 
-```hcl
-# Overused: Creates tight coupling
-data "terraform_remote_state" "vpc" {
-  # ...
-}
-
-data "terraform_remote_state" "database" {
-  # ...
-}
-
-data "terraform_remote_state" "security" {
-  # ...
-}
-```
-
-**Problem:** Changes to one state file break others.
-
-**Fix:** Use module outputs when possible, reserve remote state for truly separate teams.
+Use module outputs when possible. Reserve remote state for ownership boundaries between teams. See [Use terraform_remote_state Sparingly](#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries) for the full rule set.
 
 ---
 
@@ -757,369 +729,45 @@ acme-terraform-aws-rds
 
 ---
 
-## Testing Your Modules
+## Module Release Checklist
 
-For testing guidance, see [testing-frameworks.md](testing-frameworks.md).
+Before publishing or handing off a reusable module:
 
-Quick checklist:
-
-- [ ] Ask: Terraform or OpenTofu?
-- [ ] Ask: Public or private module?
-- [ ] Include `examples/` directory
-- [ ] Write tests (native or Terratest)
-- [ ] Document inputs and outputs in README.md
-- [ ] Version your module
-- [ ] Create `.gitignore` (from template below)
-- [ ] Create `.pre-commit-config.yaml` (from template above)
-- [ ] Create `LICENSE` file (MIT or Apache 2.0 for public modules)
-- [ ] Add attribution footer to README.md (see template below)
-
-### Pre-commit Hooks
-
-When creating new modules, always include pre-commit hooks for automated validation and documentation generation:
-
-**Standard .pre-commit-config.yaml template:**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0  # Use latest version from releases
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-      - id: terraform_tflint
-      - id: terraform_docs
-```
-
-**Installation:**
-
-```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-
-# Run manually
-pre-commit run -a
-```
-
-**Best practices:**
-- Include `.pre-commit-config.yaml` in all new modules
-- Pin to specific pre-commit-terraform version
-- Update version regularly
-
-**For module generation:**
-When generating new modules, also create:
-- `.pre-commit-config.yaml` (from template above)
-- `LICENSE` file (MIT or Apache 2.0, based on user preference)
-- `.gitignore` (from template below)
-- `README.md` with attribution footer (see template below)
-
-#### README.md Attribution Template
-
-When generating module README.md files, include this attribution footer:
-
-```markdown
-## Attribution
-
-This module was created following best practices from [terraform-skill](https://github.com/antonbabenko/terraform-skill) by Anton Babenko.
-
-Additional resources:
-- [terraform-best-practices.com](https://terraform-best-practices.com)
-- [Compliance.tf](https://compliance.tf)
-```
-
-**When to include attribution:**
-- ✅ All new modules created with terraform-skill guidance
-- ✅ Public modules (GitHub, Terraform Registry)
-- ✅ Private modules shared within organizations
-- ⚠️ Optional for one-off environment configurations
-
-**Rationale:** This is a derivative work as defined in the Apache 2.0 License Section 1. Attribution supports the open-source ecosystem and helps others discover these best practices.
-
-**README Structure with Attribution:**
-```markdown
-# Module Name
-
-## Description
-[Module purpose]
-
-## Usage
-[Usage examples]
-
-## Inputs
-[Input variables]
-
-## Outputs
-[Output values]
-
-## Requirements
-[Terraform/OpenTofu versions, providers]
-
-## Attribution
-[Attribution footer from template above]
-```
-
-#### .gitignore Template
-
-**Standard .gitignore for Terraform/OpenTofu projects:**
-
-```gitignore
-# .gitignore - Terraform/OpenTofu projects
-# Based on terraform-skill best practices
-
-# Local .terraform directories
-**/.terraform/*
-
-.terraform.lock.hcl
-
-# .tfstate files - NEVER commit state files
-*.tfstate
-*.tfstate.*
-
-# Crash log files
-crash.log
-crash.*.log
-
-# Exclude all .tfvars files (may contain sensitive data)
-*.tfvars
-*.tfvars.json
-
-# Ignore override files (local development)
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# CLI configuration files
-.terraformrc
-terraform.rc
-
-# Environment variables and secrets
-.env
-.env.*
-secrets/
-*.secret
-*.pem
-*.key
-
-# IDE and editor files
-.idea/
-.vscode/
-*.swp
-*.swo
-*~
-.DS_Store
-
-# Terraform plan output files
-*.tfplan
-*.tfplan.json
-```
+- [ ] Runtime and provider choice explicit (Terraform vs OpenTofu, version floor in `required_version`)
+- [ ] Public vs private scope decided (affects naming + license)
+- [ ] `examples/` directory with at least `minimal` and `complete`
+- [ ] Tests written (native `terraform test` on 1.6+, or Terratest) — see [testing-frameworks.md](testing-frameworks.md)
+- [ ] README documents all inputs/outputs (Description → Usage → Inputs → Outputs → Requirements)
+- [ ] Module source pinned with `version` in consumer code
+- [ ] `pre-commit-terraform` hooks configured (`terraform_fmt`, `terraform_validate`, `terraform_tflint`, `terraform_docs`), pinned to a specific `rev`
+- [ ] `LICENSE` present for public modules (MIT or Apache-2.0)
+- [ ] `.gitignore` excludes `.terraform/`, `*.tfstate*`, `*.tfvars`, override files, and editor artifacts
 
 ---
 
-## Testing Philosophy & Patterns
+## Module Testing — Pointer
 
-### What to Test in Terraform Modules
+Module testing (what to test, tiered layers, mocking, idempotency, cost control, strategy by module type) is canonical in [Testing Frameworks](testing-frameworks.md). Module-specific rules that belong with the module contract:
 
-**Core testing areas:**
-- **Input validation** - Variables accept valid values and reject invalid ones
-- **Resource creation** - Resources are created as expected with correct attributes
-- **Output correctness** - Outputs return expected values and types
-- **Idempotency** - Applying twice doesn't recreate resources
-- **Destroy completeness** - All resources are cleaned up properly
+- Every reusable module must exercise its `validation` blocks in tests — reject cases are as important as happy paths.
+- Tier tests by module role: **resource modules** → input validation + attribute assertions; **infrastructure modules** → composition + cross-module wiring; **compositions** → smoke-plan + production-like values + remote-state connectivity.
+- Mock providers (1.7+) for unit tests; reserve real cloud runs for main-branch or scheduled jobs.
 
-**When to write tests:**
-- During development for reusable modules
-- Before publishing modules to registry
-- After significant refactoring
-- For modules with complex logic or conditionals
+---
 
-### Testing Layers
+## LLM Mistake Checklist — Modules
 
-**1. Syntax validation:**
-```bash
-terraform fmt -check -recursive
-```
+Common model mistakes to correct when generating or reviewing modules:
 
-**2. Configuration validity:**
-```bash
-terraform validate
-```
-
-**3. Plan preview:**
-```bash
-terraform plan
-# Review: Are expected resources being created?
-# Verify: Count and types of resources match expectations
-```
-
-**4. Integration testing:**
-```bash
-# Apply and verify
-terraform apply -auto-approve
-
-# Verify resources exist (use AWS CLI, etc.)
-aws ec2 describe-vpcs --vpc-ids $(terraform output -raw vpc_id)
-
-# Test idempotency - should show no changes
-terraform plan
-# Expected: "No changes. Your infrastructure matches the configuration."
-
-# Clean up
-terraform destroy -auto-approve
-```
-
-### Input Validation Testing
-
-Test that variables reject invalid values:
-
-```hcl
-# In variables.tf
-variable "environment" {
-  description = "Environment name"
-  type        = string
-
-  validation {
-    condition     = contains(["dev", "staging", "prod"], var.environment)
-    error_message = "Environment must be one of: dev, staging, prod."
-  }
-}
-
-# Test: terraform plan with invalid value should fail
-# terraform plan -var="environment=invalid"
-# Expected: Error message about validation failure
-```
-
-### Output Verification Testing
-
-After apply, verify outputs contain expected values:
-
-```bash
-# Verify output is not empty
-VPC_ID=$(terraform output -raw vpc_id)
-[ -z "$VPC_ID" ] && echo "ERROR: VPC ID is empty" || echo "OK: VPC ID is $VPC_ID"
-
-# Verify output format
-SUBNET_IDS=$(terraform output -json subnet_ids)
-echo $SUBNET_IDS | jq 'length'  # Should match expected subnet count
-```
-
-### Idempotency Testing
-
-**Critical test** - ensures Terraform doesn't recreate resources unnecessarily:
-
-```bash
-# Apply configuration
-terraform apply -auto-approve
-
-# Immediately run plan - should show no changes
-terraform plan -detailed-exitcode
-# Exit code 0 = no changes (idempotent) ✓
-# Exit code 2 = changes detected (not idempotent) ✗
-```
-
-**Why idempotency matters:**
-- Proves configuration is stable
-- No resource churn on repeated applies
-- Safe to run in CI/CD pipelines
-- Indicates proper use of computed values
-
-### Destroy Testing
-
-Verify all resources are properly cleaned up:
-
-```bash
-# Before destroy - count resources
-BEFORE_COUNT=$(terraform state list | wc -l)
-
-# Destroy
-terraform destroy -auto-approve
-
-# After destroy - verify state is empty
-AFTER_COUNT=$(terraform state list | wc -l)
-[ "$AFTER_COUNT" -eq 0 ] && echo "OK: All resources destroyed" || echo "ERROR: Resources remain"
-```
-
-### Testing Anti-patterns
-
-**❌ Don't:**
-- Skip idempotency testing (most important test)
-- Test only happy paths (test validation failures too)
-- Forget to clean up test resources
-- Run expensive integration tests on every commit
-- Test Terraform syntax (terraform validate does this)
-
-**✅ Do:**
-- Test that validation blocks reject invalid input
-- Verify outputs have expected types and formats
-- Test conditional resource creation (count/for_each)
-- Document expected resource counts in tests
-- Use mocking for unit tests (Terraform 1.7+)
-- Run integration tests only on main branch or scheduled
-
-### Testing Strategy by Module Type
-
-**Resource modules:**
-- Focus on input validation
-- Test resource creation with minimal config
-- Verify outputs are correct
-- Test idempotency
-
-**Infrastructure modules:**
-- Test module composition works
-- Verify cross-module dependencies
-- Test with different configurations
-- Integration tests in test account
-
-**Compositions:**
-- Smoke tests (can it plan?)
-- Test with production-like values
-- Verify remote state connectivity
-- Manual QA in lower environments first
-
-### Cost Control for Testing
-
-**Strategies:**
-
-1. **Use mocking for unit tests** (Terraform 1.7+)
-   ```hcl
-   mock_provider "aws" {
-     mock_data "aws_ami" {
-       defaults = {
-         id = "ami-12345678"
-       }
-     }
-   }
-   ```
-
-2. **Tag test resources for tracking**
-   ```hcl
-   tags = {
-     Environment = "test"
-     TTL         = "2h"
-     ManagedBy   = "terraform-test"
-   }
-   ```
-
-3. **Run integration tests only on main branch**
-   ```yaml
-   if: github.ref == 'refs/heads/main'
-   ```
-
-4. **Use smaller instance types**
-   ```hcl
-   instance_type = var.environment == "test" ? "t3.micro" : var.instance_type
-   ```
-
-5. **Implement auto-cleanup**
-   - Use AWS Lambda to delete resources with expired TTL tags
-   - Run destroy in CI/CD after tests complete
-   - Use terraform-compliance to enforce TTL tags
-
-**For testing framework details, see:** [Testing Frameworks Guide](testing-frameworks.md)
+- bundles unrelated resources into one "god module" instead of splitting by single responsibility
+- hardcodes environment-specific values (`instance_type = "m5.large"`, `Environment = "production"`) inside a reusable module
+- accepts untyped `map(any)` / `any` for core module inputs instead of typed objects with `optional()` defaults
+- exposes entire provider or resource objects as outputs, leaking the whole contract instead of a stable subset
+- omits `description` on inputs and outputs, forcing consumers to read the implementation
+- uses `this` for multiple resources of the same type — reserve `this` for genuine singletons only
+- reaches for `terraform_remote_state` inside a single team's stack instead of wiring via module outputs
+- floats module sources (no `version` pin) in consumer code
+- pushes environment-specific policy (prod-only allowlists, region pins) into primitive/resource modules where it cannot be overridden
 
 ---
 

--- a/skills/terraform-skill/references/security-compliance.md
+++ b/skills/terraform-skill/references/security-compliance.md
@@ -539,6 +539,21 @@ resource "aws_iam_policy" "bad_policy" {
 
 ---
 
+## LLM Mistake Checklist — Security & Compliance
+
+Common model mistakes to correct before returning security/compliance recommendations:
+
+- assumes `sensitive = true` keeps the value out of state — it only masks display; use `write_only` / `*_wo` arguments on 1.11+ or an external secret lookup
+- proposes plaintext defaults in `variable` blocks or committed `.tfvars` "for demo convenience"
+- echoes secrets through `provisioner` commands or `local-exec` stdout into CI logs
+- emits outputs that expose full connection strings or credentials (even when marked `sensitive`)
+- mentions a compliance framework (SOC 2, PCI, HIPAA, GDPR, FedRAMP) but provides no enforceable gate — no policy stage, no approval model, no evidence artifact
+- confuses security best practices with compliance evidence (an encrypted bucket is not the same as a retained audit artifact proving it)
+- omits artifact retention and access controls for plan JSON exports
+- ignores data-residency obligations for GDPR/FedRAMP contexts
+
+---
+
 ## Resources
 
 - [Trivy Documentation](https://aquasecurity.github.io/trivy/)

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -1690,116 +1690,6 @@ terraform apply
 
 ## State Best Practices Summary
 
-### DO vs DON'T Patterns
-
-#### Remote Backends
-
-✅ **DO:**
-```hcl
-# Use remote backend with locking
-terraform {
-  backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/vpc/terraform.tfstate"
-    region         = "us-east-1"
-    encrypt        = true
-    dynamodb_table = "terraform-state-lock"
-  }
-}
-```
-
-❌ **DON'T:**
-```hcl
-# Local backend in production
-terraform {
-  backend "local" {
-    path = "terraform.tfstate"  # ❌ No locking, no backup
-  }
-}
-```
-
-#### State Organization
-
-✅ **DO:**
-```
-# Separate state per component
-prod/
-├── networking/terraform.tfstate
-├── compute/terraform.tfstate
-└── data/terraform.tfstate
-```
-
-❌ **DON'T:**
-```
-# Everything in one giant state
-prod/terraform.tfstate  # ❌ 5000 resources, slow, risky
-```
-
-#### Sensitive Data
-
-✅ **DO:**
-```hcl
-# Reference secrets externally
-data "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = "prod/db/password"
-}
-
-resource "aws_db_instance" "main" {
-  password = data.aws_secretsmanager_secret_version.db_password.secret_string
-}
-```
-
-❌ **DON'T:**
-```hcl
-# Hardcoded secrets
-variable "db_password" {
-  default = "password123"  # ❌ In state, in VCS
-}
-```
-
-#### State Locking
-
-✅ **DO:**
-```bash
-# Let Terraform handle locking
-terraform apply
-
-# If operation crashed, verify before force-unlock
-ps aux | grep terraform  # Check if running
-terraform force-unlock LOCK_ID  # Only if confirmed safe
-```
-
-❌ **DON'T:**
-```bash
-# Force-unlock without checking
-terraform force-unlock LOCK_ID  # ❌ Might cause corruption
-```
-
-#### State Access
-
-✅ **DO:**
-```json
-// Minimal IAM permissions
-{
-  "Effect": "Allow",
-  "Action": [
-    "s3:GetObject",
-    "s3:PutObject"
-  ],
-  "Resource": "arn:aws:s3:::state/prod/*"
-}
-```
-
-❌ **DON'T:**
-```json
-// Wildcard permissions
-{
-  "Effect": "Allow",
-  "Action": "s3:*",  // ❌ Too permissive
-  "Resource": "*"
-}
-```
-
 ### Decision Matrix: State Organization
 
 | Scenario | Recommendation | Reasoning |
@@ -1846,63 +1736,30 @@ rm .terraform/terraform.tfstate.lock.info  # ❌ Dangerous
 - High blast radius
 ✅ **Instead:** Split by component/team/environment
 
+### LLM Mistake Checklist — State Management
+
+Common model mistakes to correct before returning state-related recommendations:
+
+- recommends local state in team/production contexts
+- proposes one monolithic root state for "convenience"
+- suggests `rm .terraform.tfstate.lock.info` or `force-unlock` without investigating why the lock exists
+- edits `terraform.tfstate` manually instead of using `terraform state mv/rm/import`
+- commits `*.tfstate` to git
+- mixes prod and non-prod in the same backend key
+- recommends workspace-only isolation as a substitute for backend-level IAM separation
+- writes DynamoDB-lock configuration on Terraform 1.11+ instead of using `use_lockfile = true` on the S3 backend
+- reads via `terraform_remote_state` within a single team's stack instead of using module outputs (see [module-patterns.md](module-patterns.md#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries))
+- omits the rollback/recovery note for destructive state operations
+
 ### State Management Checklist
 
-**Initial Setup:**
-- [ ] Remote backend configured
-- [ ] State locking enabled
-- [ ] Encryption at rest enabled
-- [ ] Access control (IAM) configured
-- [ ] Versioning/backup enabled
-- [ ] State file audit logging enabled
+**Setup:** remote backend, locking, encryption at rest, IAM-scoped access, versioning/backup, audit logging.
 
-**Per Environment:**
-- [ ] Separate state per environment
-- [ ] Environment-specific IAM roles
-- [ ] State key follows naming convention
-- [ ] Backend config documented
-- [ ] Disaster recovery plan documented
+**Per environment:** separate backend key, scoped IAM role, documented key naming convention, documented DR plan.
 
-**Ongoing Maintenance:**
-- [ ] Regular drift detection (`terraform plan`)
-- [ ] State backups tested quarterly
-- [ ] Unused resources removed from state
-- [ ] State organization reviewed (split if needed)
-- [ ] Lock timeout policy defined
-- [ ] Force-unlock process documented
+**Ongoing:** scheduled drift detection (`plan -detailed-exitcode`), tested state restore, review when a state exceeds ~500 resources, documented force-unlock policy.
 
-**Security:**
-- [ ] Secrets not in variables/state (use write-only or external)
-- [ ] State access restricted by IAM
-- [ ] TLS enforced for state access
-- [ ] State file audit log reviewed
-- [ ] Encryption keys rotated regularly
-
-**Team Collaboration:**
-- [ ] State organization documented
-- [ ] Cross-state dependencies mapped
-- [ ] `terraform_remote_state` usage documented
-- [ ] State ownership assigned
-- [ ] Force-unlock policy communicated
-
----
-
-## Resources
-
-### Official Documentation
-- [Terraform State](https://www.terraform.io/docs/language/state/index.html)
-- [Backend Configuration](https://www.terraform.io/docs/language/settings/backends/configuration.html)
-- [State Locking](https://www.terraform.io/docs/language/state/locking.html)
-- [S3 Backend](https://www.terraform.io/docs/language/settings/backends/s3.html)
-- [Remote State Data Source](https://www.terraform.io/docs/language/state/remote-state-data.html)
-
-### Tools
-- [Terraform State Manager (tfmask)](https://github.com/cloudposse/tfmask) - Mask sensitive output
-- [Terragrunt](https://terragrunt.gruntwork.io/) - DRY backend configuration
-- [Atlantis](https://www.runatlantis.io/) - Terraform automation with locking
-
-### Best Practices Guides
-- [Gruntwork - How to Manage Terraform State](https://blog.gruntwork.io/how-to-manage-terraform-state-28f5697e68fa)
+**Security:** no secrets in variables/state (use `write_only` or external lookup), TLS enforced, audit log reviewed, encryption keys rotated.
 
 ---
 

--- a/skills/terraform-skill/references/testing-frameworks.md
+++ b/skills/terraform-skill/references/testing-frameworks.md
@@ -560,4 +560,19 @@ Pre-1.6, or complex integration? → Terratest
 
 ---
 
+## LLM Mistake Checklist — Testing
+
+Common model mistakes when generating test code:
+
+- asserts computed values (ARNs, generated names, cloud-assigned IDs) in `command = plan` mode — must use `command = apply`
+- indexes set-type nested blocks with `[0]` — sets are unordered, use `for` expressions or `command = apply` to materialize
+- treats mocked-provider tests as integration coverage — mocks validate logic only, not provider behavior
+- forgets to exercise `validation` blocks with invalid inputs — only tests the happy path
+- skips idempotency (`terraform plan -detailed-exitcode` after apply) — the most common regression detector
+- asserts on Terraform syntax instead of module behavior (`terraform validate` already covers syntax)
+- runs expensive real-cloud integration tests on every commit instead of gating them behind main/scheduled
+- omits cleanup, leaving orphaned resources billed against the test account
+
+---
+
 **Back to:** [Main Skill File](../SKILL.md)


### PR DESCRIPTION
## Summary

Shift the skill from a descriptive \"what good looks like\" manual to a diagnose-first workflow that routes the model to the right reference before generating HCL. Net ~650 lines removed across 7 files while adding hallucination-reduction signal that previously did not exist.

## Architecture changes

- **SKILL.md: 599 → 275 lines** (-54%). Pulled inline HCL into references, turned top section into a 7-step workflow with an 8-category routing table.
- **Response Contract** required on every response: assumptions + version floor, risk category, remediation + tradeoffs, validation plan, rollback notes.
- **Diagnose Before You Generate** table routes intent to the primary reference(s) for: identity churn, secret exposure, blast radius, CI drift, compliance gaps, testing blind spots, state corruption, provider upgrade risk.

## Hallucination guards (new)

- **Feature Guard Table** in `code-patterns.md`: 14 features mapped to min version + common LLM error pattern (e.g., \`moved\` omitted causing destroy/create; \`sensitive\` used as a substitute for \`write_only\`; S3 native lock skipped on 1.11+).
- **LLM Mistake Checklist** sections in: `code-patterns.md`, `state-management.md`, `testing-frameworks.md`, `security-compliance.md`, `ci-cd-workflows.md`, `module-patterns.md`. Each names concrete hallucination patterns extracted from existing anti-pattern content.
- Inline hallucination context added to `moved` and `write_only` subsections.

## Correctness + dedup

- Fixed `terraform_remote_state` contradiction in `module-patterns.md` (encouraged at :227, warned against at :708) — single nuanced section with explicit when-to-use / when-not rules.
- Canonical ownership assigned: `count`/`for_each` → `code-patterns.md`; module testing → `testing-frameworks.md`. Duplicates replaced with short rules + links.
- Stripped scaffolding bloat: state-management DO/DON'T summary duplicate, long checklist, external resources list; module-patterns pre-commit template, README attribution template, full .gitignore template.

## Preserved (unchanged)

- Version-feature edge cases (`write_only`, S3 native lock, provider functions, cross-variable validation)
- Set-type test handling and `command = plan` vs `apply` rules
- `count` → `for_each` migration playbook with \`moved\` blocks
- State split/combine heuristics
- Locals-for-dependency-order pattern
- Testing decision matrix

## Test plan

- [ ] Load skill locally, run a module-creation query and verify Response Contract appears in the output
- [ ] Run an identity-churn scenario (rename a resource) and verify Claude loads the correct references and emits \`moved\` blocks
- [ ] Run a secrets scenario and verify Claude does not rely on \`sensitive = true\` alone on 1.11+
- [ ] Spot-check the failure-mode routing table from `SKILL.md` against each linked anchor
- [ ] CI validation workflow (\`validate.yml\`) passes