### PR TITLE
feat: add Provider Removal guidance

### DIFF
--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -45,6 +45,7 @@ Never recommend direct production apply without a reviewed plan artifact and app
 | **Testing blind spots** | Plan-only validation of computed values, set-type indexing, mock/real confusion | [Testing Frameworks](references/testing-frameworks.md) |
 | **State corruption / recovery** | Stuck lock, backend migration, drift reconciliation | [State Management](references/state-management.md) |
 | **Provider upgrade risk** | Breaking-change provider bump, unpinned modules | [Code Patterns: versions](references/code-patterns.md#version-management), [Module Patterns](references/module-patterns.md) |
+| **Provider lifecycle** | Removing a provider with resources still in state, orphaned resources, `removed` block usage | [State Management: Provider Removal](references/state-management.md#provider-removal) |
 
 ## When to Use This Skill
 

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -1190,6 +1190,39 @@ terraform plan
 terraform apply -refresh-only
 ```
 
+### Provider Removal
+
+Terraform calls the provider plugin's `Destroy` RPC during apply. Keep the provider installed until every resource for that provider is destroyed or removed from state.
+
+| Goal | Use | Tradeoff |
+|------|-----|----------|
+| Remove provider and destroy the real resource | Two-phase removal (default) | Safe; requires `apply` |
+| Remove provider and keep the real resource | `removed` block (Terraform 1.7+, OpenTofu 1.7+) | Declarative; real resource stays but becomes unmanaged |
+| Remove from state manually | `terraform state rm <addr>` | Orphans the real resource; use only when intentionally abandoning |
+
+**Two-phase removal**
+
+1. **Phase 1 — destroy resources, keep provider:** Delete resource blocks from config (or mark for destruction). Keep the `provider` block and `required_providers` entry. Run `terraform plan` and confirm target resources show `destroy`. Run `terraform apply`. Run `terraform state list` and verify no resources remain for that provider.
+2. **Phase 2 — remove provider:** Remove the `provider` block and the `required_providers` entry. Run `terraform init`. Run `terraform plan` and expect no changes and no errors.
+
+**`removed` block**
+
+```hcl
+removed {
+  from = vault_policy.ops
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+**Rules**
+
+- ❌ Remove the provider block first: plan cannot resolve the resource type → hard error.
+- ✅ Same rule applies to provider aliases and multi-provider modules.
+- ✅ Plain `terraform init` after removal; `-upgrade` is for bumping existing providers, not required here.
+
 ---
 
 ## Multi-Team State Isolation


### PR DESCRIPTION
## Summary

Addresses #5 (@JulesClaussen suggestion, credited via `Co-authored-by:`).

Adds guidance on removing a Terraform/OpenTofu provider when it still has managed resources. LLMs commonly miss this pattern: removing the `provider` block + `required_providers` entry in the same PR as resource deletion → hard error because Terraform needs the provider plugin to call its Destroy RPC.

## What's in

- **SKILL.md:** new "Provider lifecycle" row in the Diagnose table (symptoms: removing a provider with resources in state, orphaned resources, `removed` block usage), linked to the reference section.
- **references/state-management.md:** new `### Provider Removal` section under `## State Migration`:
  - Decision table (`destroy` vs `removed` block vs `state rm`) as first step, matching the LLM's classification path
  - Two-phase removal as the default playbook
  - `removed` block alternative (Terraform 1.7+, OpenTofu 1.7+)
  - Rules section with ❌/✅ covering the common LLM mistake + provider-aliases caveat + `init -upgrade` clarification

## Format review — consulted GPT/Codex on LLM consumption efficiency

Original draft was ~500 tokens with a human-pedagogical structure (phases → alternatives → why). Codex reviewed and recommended:

- Decision table first (matches LLM retrieval path: identify intent → pick branch → execute)
- Drop the `versions.tf` before/after diff (redundant with explicit phase steps — human scaffolding, not LLM signal)
- Compress "Why this matters" prose into terse ❌/✅ Rules

Result: **~25-30% token reduction** (~500 → ~340 tokens) while preserving every technical fact (Destroy RPC dependency, two-phase ordering, `removed` block, `state rm` consequences, provider-alias caveat).

## Refinements over the original suggestion in #5

- Dropped non-universal assumption about `vars.tf` / provider-config file split
- Noted `terraform init` (not `-upgrade`) suffices after removal
- Added `removed` block alternative (state-only removal, don't destroy cloud resource)
- Noted rule extends to provider aliases and multi-provider modules

## Test plan

- [ ] `validate.yml` passes on new content
- [ ] `references/state-management.md#provider-removal` anchor resolves from SKILL.md diagnose row
- [ ] Scenario: ask agent to "remove the Vault provider from my Terraform config" → expect two-phase pattern, not single-PR removal
- [ ] Scenario: ask agent to "drop this resource from state but keep the cloud resource" → expect `removed` block with `lifecycle { destroy = false }`

Closes #5.