### PR TITLE
docs: codify LLM content rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,34 @@ When adding content, ask: **Does this belong in SKILL.md (decision frameworks, k
 - **Version-specific features** clearly marked (e.g., `Terraform 1.6+`)
 - **Token budget:** SKILL.md target <500 lines; current 524 is justified but don't grow further
 
+### LLM Consumption Rules (enforce in every PR review)
+
+These rules tune content for the **primary reader: an LLM retrieving facts to answer a user query**, not a human reading the guide end-to-end. They are **mandatory** for every addition to `SKILL.md` and `references/*.md`. Reviewers must reject PRs that violate them.
+
+**1. Shape — decision table before playbook.** The LLM retrieval path is: classify intent → pick branch → execute. When a topic has multiple viable approaches, open the section with a decision table (`Goal | Use | Tradeoff`) before any phase steps or default procedure. Never bury branching in prose or push alternatives to the end.
+
+**2. Cut human scaffolding.** Before/after config diffs, "Why this matters" paragraphs, and pedagogical asides are human-only signal. If the phase steps already name the required action, a before/after diff is redundant and must be dropped. Teaching tone ≠ retrieval value.
+
+**3. Compress prose → ❌/✅ Rules.** Any sentence starting with "You should...", "Note that...", "Keep in mind...", "It's important to..." — rewrite as terse imperative ❌/✅ bullet. One fact per bullet. Direct verbs only: `Keep`, `Remove`, `Run`, `Confirm`, `Use`, `Avoid`, `Scope`.
+
+**4. Every artifact earns its tokens.** Every code block, table, and example must add a fact not present in the prose. If it only restates, cut it. No "for completeness" content.
+
+**5. Anchor stability.** SKILL.md routes to specific `#anchor` headings in reference files. Rewrites may restructure internal subsections, but must preserve the top-level `### Heading` that the SKILL.md diagnose table points to.
+
+**6. Retrieval-first ordering.** Within a section, order content by what the LLM needs first: (a) decision table, (b) default procedure, (c) alternatives, (d) rules/gotchas as ❌/✅. Rationale lives in ≤1 opening sentence, never a closing "Why this matters" block.
+
+**Token target per reference subsection:** under 400 tokens (~1,600 chars). If larger, split or compress — do not ship a 600-token walkthrough when 350 tokens carries the same decision value.
+
+**Pre-merge checklist for any content PR:**
+
+- [ ] Decision table precedes playbook (if multiple approaches exist)
+- [ ] No before/after diff that merely restates the phase steps
+- [ ] No paragraph starting with "Why this matters" / "Note" / "Keep in mind" — all converted to ❌/✅
+- [ ] Every code block / table adds a fact not in surrounding prose
+- [ ] Subsection under 400 tokens
+- [ ] Anchors referenced from SKILL.md remain stable
+- [ ] For substantive new sections, consult an external LLM expert (e.g. GPT via `mcp__codex__codex`) for format/compression review before merge
+
 ## PR Requirements
 
 PRs must include testing evidence showing baseline behavior (before) vs. compliance behavior (after) for affected scenarios from `tests/baseline-scenarios.md`. See `.github/PULL_REQUEST_TEMPLATE.md` for the full checklist.


### PR DESCRIPTION
## Summary

Codifies the LLM-content-format rules that came out of consulting GPT/Codex on PR #18's Provider Removal section. Rules are now **mandatory** in `CLAUDE.md § LLM Consumption Rules` with a pre-merge checklist reviewers must apply.

## Why

PR #18 started as a ~500-token draft in human-pedagogical format (phases → alternatives → "why this matters"). Codex review produced a ~340-token decision-table-first version with identical decision value. Without codifying the rules, the next contributor ships the same too-verbose shape and we repeat the compression round.

## Rules codified

1. **Shape** — decision table before playbook (LLM classify → branch → execute path)
2. **Cut human scaffolding** — no before/after diffs that just restate phase steps, no "Why this matters" paragraphs
3. **Compress prose → ❌/✅ rules** — terse imperative bullets, one fact per bullet
4. **Every artifact earns its tokens** — no restating blocks/tables "for completeness"
5. **Anchor stability** — preserve `### Heading` referenced from SKILL.md diagnose table
6. **Retrieval-first ordering** — decision → procedure → alternatives → rules/gotchas

Plus:
- **Token target:** subsection under 400 tokens (~1,600 chars)
- **Pre-merge checklist** of 7 items reviewers apply
- Explicit recommendation: consult external LLM (e.g. `mcp__codex__codex`) for format review on substantive new content

## Changes

Single file: `CLAUDE.md` — added `### LLM Consumption Rules` subsection under `## SKILL.md Architecture` (after existing `### Content Standards`). +28 lines.

## Test plan

- [ ] Review next content PR using the new checklist — confirm the checks are applicable and specific
- [ ] Verify `CLAUDE.md` still renders cleanly on GitHub
- [ ] No broken links introduced

## Related

- Refs #18 (Provider Removal — the PR that triggered the codification)