### PR TITLE
fix: factual corrections across all reference files (7-reviewer panel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .claude/settings.local.json
+docs/
+tmp-*/

--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -190,7 +190,7 @@ See [Security & Compliance](references/security-compliance.md) for trivy/checkov
 
 **Never use local state in teams or production.** Remote backends provide automatic locking, encryption, versioning, audit logging, and safe collaboration.
 
-### Minimum Viable Backend (AWS S3, 1.11+)
+### Minimum Viable Backend (AWS S3, 1.10+)
 
 ```hcl
 terraform {
@@ -199,12 +199,12 @@ terraform {
     key           = "prod/vpc/terraform.tfstate"
     region        = "us-east-1"
     encrypt       = true
-    use_lockfile  = true   # Native S3 locking, 1.11+
+    use_lockfile  = true   # Native S3 locking, 1.10+
   }
 }
 ```
 
-On Terraform < 1.11, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking — see the State Management reference for syntax.
+On Terraform < 1.10, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking — see the State Management reference for syntax.
 
 ### State Organization
 
@@ -242,10 +242,10 @@ Commit `.terraform.lock.hcl` intentionally. Keep provider/runtime upgrades in a 
 | Native `terraform test` | 1.6+ | Built-in test framework |
 | Mock providers | 1.7+ | Cost-free unit testing |
 | `removed` blocks | 1.7+ | Declarative resource removal |
-| Provider-defined functions | 1.8+ | Provider-specific transformations |
-| Cross-variable validation | 1.9+ | Validate relationships between variables |
+| Provider-defined functions | 1.8+ | Provider-specific transformations (requires provider to declare functions) |
+| Cross-variable validation | 1.9+ | Reference other `var.*` in `validation` blocks |
 | `write_only` arguments | 1.11+ | Secrets never stored in state |
-| S3 native lock-file | 1.11+ | State locking without DynamoDB |
+| S3 native lock-file | 1.10+ | State locking without DynamoDB |
 
 Before emitting a feature, verify the runtime floor. See [Code Patterns: Feature Guard Table](references/code-patterns.md#feature-guard-table--version-floor--common-llm-errors) for the full table with common LLM error patterns per feature.
 
@@ -254,7 +254,8 @@ Before emitting a feature, verify the runtime floor. See [Code Patterns: Feature
 - **Terraform 1.0-1.5 / OpenTofu 1.0-1.5**: Terratest for integration, static analysis + plan validation only (no native tests).
 - **1.6+**: native `terraform test` / `tofu test` available — migrate simple unit tests, keep Terratest for complex integration.
 - **1.7+**: mock providers cut test cost — mock for unit tests, real runs for final integration.
-- **1.11+**: `write_only` arguments + S3 native lock are the correct default for new configurations.
+- **1.10+**: S3 native lock-file (`use_lockfile`) is the correct default for new configurations — DynamoDB locking is no longer required.
+- **1.11+**: `write_only` arguments for secret handling keep credentials out of state.
 - **Terraform vs OpenTofu**: both supported. For licensing, governance, and feature delta, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference.md#terraform-vs-opentofu-comparison).
 
 ## Reference Files

--- a/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/skills/terraform-skill/references/ci-cd-workflows.md
@@ -391,7 +391,7 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     env:
-      TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+      TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/terraform-plugin-cache
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
@@ -402,7 +402,7 @@ jobs:
       - name: Cache Terraform Plugins
         uses: actions/cache@v4
         with:
-          path: ~/.terraform.d/plugin-cache
+          path: ${{ runner.temp }}/terraform-plugin-cache
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
 
       - name: Terraform Init

--- a/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/skills/terraform-skill/references/ci-cd-workflows.md
@@ -25,7 +25,10 @@ This document provides detailed CI/CD workflow templates and optimization strate
 # .github/workflows/terraform.yml
 name: Terraform
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   validate:
@@ -43,11 +46,13 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.50.3
+      - name: TFLint Init
+        run: tflint --init
       - name: TFLint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-          tflint --init
-          tflint
+        run: tflint
 
   test:
     needs: validate
@@ -61,9 +66,9 @@ jobs:
 
       # Or for Terratest:
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: 'stable'
 
       - name: Run Terratest
         run: |
@@ -170,9 +175,9 @@ test:
   stage: test
   script:
     - terraform test
-  only:
-    - merge_requests
-    - main
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 plan:
   extends: .terraform_template
@@ -183,9 +188,9 @@ plan:
     paths:
       - ${TF_ROOT}/tfplan
     expire_in: 1 week
-  only:
-    - merge_requests
-    - main
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 apply:
   extends: .terraform_template
@@ -194,9 +199,9 @@ apply:
     - terraform apply tfplan
   dependencies:
     - plan
-  only:
-    - main
-  when: manual
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
   environment:
     name: production
 ```
@@ -241,7 +246,7 @@ terraformOptions := &terraform.Options{
     Vars: map[string]interface{}{
         "tags": map[string]string{
             "Environment": "test",
-            "TTL":         "2h",
+            "CreatedAt":   time.Now().Format(time.RFC3339),
             "CreatedBy":   "CI",
             "JobID":       os.Getenv("GITHUB_RUN_ID"),
         },
@@ -258,17 +263,29 @@ terraformOptions := &terraform.Options{
 ```bash
 #!/bin/bash
 # cleanup-test-resources.sh
+# Resources are tagged with CreatedAt = ISO8601 timestamp (RFC3339).
+# AWS resourcegroupstaggingapi tag filters only support equality, so we
+# fetch by Environment=test and filter by timestamp client-side with jq.
 
-# Find and terminate instances older than 2 hours with test tag
+set -euo pipefail
+
+CUTOFF=$(date -u -d '2 hours ago' +%s)
+
 aws resourcegroupstaggingapi get-resources \
   --tag-filters Key=Environment,Values=test \
-  --query 'ResourceTagMappingList[?Tags[?Key==`TTL` && Value<`'$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S)'`]].ResourceARN' \
-  --output text | \
-  while read arn; do
-    instance_id=$(echo $arn | grep -oP 'instance/\K[^/]+')
-    if [ ! -z "$instance_id" ]; then
+  --query 'ResourceTagMappingList[]' \
+  --output json | \
+  jq -r --argjson cutoff "$CUTOFF" '
+    .[]
+    | select(
+        any(.Tags[]; .Key == "CreatedAt" and (.Value | fromdateiso8601) < $cutoff)
+      )
+    | .ResourceARN
+  ' | while read -r arn; do
+    instance_id=$(echo "$arn" | grep -oP 'instance/\K[^/]+' || true)
+    if [ -n "$instance_id" ]; then
       echo "Terminating instance: $instance_id"
-      aws ec2 terminate-instances --instance-ids $instance_id
+      aws ec2 terminate-instances --instance-ids "$instance_id"
     fi
   done
 ```
@@ -368,13 +385,28 @@ terraform {
 ### 5. Cache Terraform Plugins
 
 ```yaml
-# GitHub Actions
-- name: Cache Terraform Plugins
-  uses: actions/cache@v4
-  with:
-    path: |
-      ~/.terraform.d/plugin-cache
-    key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+# GitHub Actions — set TF_PLUGIN_CACHE_DIR so `terraform init` actually
+# writes into the cached path, then restore the cache between runs.
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Create plugin cache dir
+        run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+      - name: Cache Terraform Plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+
+      - name: Terraform Init
+        run: terraform init
 ```
 
 ### 6. Security Scanning in CI
@@ -386,13 +418,13 @@ security-scan:
     - uses: actions/checkout@v4
 
     - name: Run Trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.29.0
       with:
         scan-type: 'config'
         scan-ref: '.'
 
     - name: Run Checkov
-      uses: bridgecrewio/checkov-action@master
+      uses: bridgecrewio/checkov-action@v12.2.0
       with:
         directory: .
         framework: terraform
@@ -483,7 +515,7 @@ projects:
   - name: production
     dir: environments/prod
     workspace: default
-    terraform_version: v1.6.0
+    terraform_version: 1.12.0
     workflow: custom
 
 workflows:
@@ -492,7 +524,7 @@ workflows:
       steps:
         - init
         - plan:
-            extra_args: ["-lock", "false"]
+            extra_args: ["-lock=false"]
     apply:
       steps:
         - apply

--- a/skills/terraform-skill/references/code-patterns.md
+++ b/skills/terraform-skill/references/code-patterns.md
@@ -334,7 +334,7 @@ moved {
 | Case | Use | Why |
 |------|-----|-----|
 | stable key set known at plan | `for_each` over static map/var | avoids count index churn on insert/remove |
-| key set unknowable at plan | `count = bool ? 1 : 0` for singleton | keys cannot be resolved at plan time |
+| key set unknowable at plan | `count = bool ? 1 : 0` for singleton | keys derived from values unknown until apply |
 
 - ❌ `depends_on` does NOT fix `Invalid for_each argument` — it orders applies, not plan-time value resolution
 - ❌ deriving `for_each` keys from another resource's computed attrs (IDs, ARNs)
@@ -421,7 +421,7 @@ output "first_subnet_id" {
 
 # ❌ BAD - Legacy pattern
 output "security_group_id" {
-  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+  value = element(concat(aws_security_group.this[*].id, [""]), 0)
 }
 ```
 
@@ -527,11 +527,10 @@ resource "aws_db_instance" "this" {
 
 ```hcl
 # AWS provider function example
-data "aws_region" "current" {}
-
 locals {
-  # Provider function (Terraform 1.8+)
-  bucket_name = provider::aws::arn_build("s3", "my-bucket", data.aws_region.current.name)
+  # provider::aws::arn_build(partition, service, region, account_id, resource)
+  # S3 ARNs are global: region and account_id are empty strings.
+  bucket_arn = provider::aws::arn_build("aws", "s3", "", "", "my-bucket")
 }
 
 # Check provider documentation for available functions
@@ -611,7 +610,10 @@ resource "aws_db_instance" "this" {
   instance_class = "db.t3.micro"
   username       = "admin"
 
-  # write-only: Terraform sends to AWS then forgets it (not in state)
+  # password_wo keeps the resource argument out of state (1.11+),
+  # but the data source still reads secret_string into state on refresh.
+  # For true state exclusion: use ephemeral (1.10+), manage_master_user_password,
+  # or inject via CI env var outside Terraform.
   password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
 }
 
@@ -692,9 +694,9 @@ resource "aws_security_group" "this" {
 version = "5.0.0"
 
 # Pessimistic constraint (recommended for stability)
-# Allows patch updates only
-version = "~> 5.0"      # Allows 5.0.x (any x), but not 5.1.0
-version = "~> 5.0.1"    # Allows 5.0.x where x >= 1, but not 5.1.0
+# The rightmost component is the one that's allowed to increment.
+version = "~> 5.0"      # 5.x: >= 5.0, < 6.0 — allows 5.1, 5.2, 5.99
+version = "~> 5.0.1"    # 5.0.x patches only: >= 5.0.1, < 5.1.0
 
 # Range constraints
 version = ">= 5.0, < 6.0"     # Any 5.x version
@@ -850,7 +852,7 @@ terraform {
 ```hcl
 # Before (0.12 style)
 output "security_group_id" {
-  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+  value = element(concat(aws_security_group.this[*].id, [""]), 0)
 }
 
 variable "config" {
@@ -927,7 +929,10 @@ resource "aws_db_instance" "this" {
   engine   = "mysql"
   username = "admin"
 
-  # write-only: Sent to AWS, not stored in state
+  # password_wo keeps the resource argument out of state (1.11+),
+  # but the data source still reads secret_string into state on refresh.
+  # For true state exclusion: use ephemeral (1.10+), manage_master_user_password,
+  # or inject via CI env var outside Terraform.
   password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
 }
 ```

--- a/skills/terraform-skill/references/module-patterns.md
+++ b/skills/terraform-skill/references/module-patterns.md
@@ -215,11 +215,12 @@ environments/prod/
 # ✅ GOOD - Remote state
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/networking/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"  # State locking
-    encrypt        = true                # Encryption at rest
+    bucket       = "my-terraform-state"
+    key          = "prod/networking/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true   # Terraform 1.10+; native S3 locking
+    # Pre-1.10 runtime: use dynamodb_table = "terraform-locks" instead
   }
 }
 ```
@@ -436,7 +437,7 @@ For public modules, always include a LICENSE file:
    | Name | Version |
    |------|---------|
    | [terraform/tofu] | >= 1.7.0 |
-   | aws | >= 6.0 |
+   | aws | ~> 5.0 |
    ```
 
 4. **Example command variations:**

--- a/skills/terraform-skill/references/quick-reference.md
+++ b/skills/terraform-skill/references/quick-reference.md
@@ -82,6 +82,7 @@ terraform import aws_instance.web i-1234567890abcdef0
 
 # Import using import blocks (1.5+)
 # Define in .tf: import { to = aws_instance.web, id = "i-123..." }
+# Note: File must not exist — Terraform refuses to overwrite.
 terraform plan -generate-config-out=imported.tf
 
 # Detect configuration drift
@@ -97,7 +98,11 @@ terraform state pull > backup-$(date +%Y%m%d).tfstate
 terraform state push backup.tfstate
 
 # Force unlock stuck state lock
+# Default: prompts for y/N confirmation
 terraform force-unlock LOCK_ID
+
+# CI-friendly (skips prompt):
+terraform force-unlock -force LOCK_ID
 ```
 
 ### State Backend Migration
@@ -192,10 +197,10 @@ Need to test Terraform/OpenTofu code?
 
 ### Terraform 1.6+ / OpenTofu 1.6+
 
-- ✅ NEW: Native `terraform test` / `tofu test`
+- ✅ NEW: Native `terraform test` / `tofu test` framework with `.tftest.hcl` files
 - ✅ Consider migrating simple tests from Terratest
 - ✅ Keep Terratest for complex integration
-- ✅ All Terraform 1.0+ features available
+- ✅ Import blocks from 1.5 available for declarative imports with `-generate-config-out`
 
 ### Terraform 1.7+ / OpenTofu 1.7+
 
@@ -212,14 +217,14 @@ Both Terraform and OpenTofu are fully supported by this skill. The choice depend
 
 | Factor | Terraform | OpenTofu |
 |--------|-----------|----------|
-| **Licensing** | Business Source License (BSL) 1.1 | Mozilla Public License 2.0 (MPL 2.0) |
+| **Licensing** | Business Source License 1.1 (BUSL-1.1) | Mozilla Public License 2.0 (MPL 2.0) |
 | **Governance** | HashiCorp (single vendor) | Linux Foundation (community-driven) |
 | **Latest Version** | 1.14+ | 1.11+ |
 | **Native Testing** | 1.6+ | 1.6+ |
 | **Mock Providers** | 1.7+ | 1.7+ |
 | **Feature Parity** | Reference implementation | Compatible fork with some additions |
 | **Enterprise Support** | HCP Terraform, Terraform Cloud | Multiple vendors |
-| **Migration Path** | N/A | Drop-in replacement for Terraform ≤1.5 |
+| **Migration Path** | N/A | Drop-in replacement for Terraform ≤1.5.x; feature-compatible fork thereafter with divergence on encryption, mock providers, provider functions, and other post-1.6 additions. Verify specific feature availability per version. |
 
 **When to choose Terraform:**
 - Using HashiCorp Terraform Cloud or HCP Terraform
@@ -230,7 +235,7 @@ Both Terraform and OpenTofu are fully supported by this skill. The choice depend
 - Prefer open-source governance model
 - Want to avoid vendor lock-in concerns
 - Building on community-driven development
-- BSL 1.1 license doesn't fit your use case
+- BUSL-1.1 license doesn't fit your use case
 
 **For this skill:**
 - Commands are shown for both: `terraform` and `tofu`
@@ -405,6 +410,7 @@ terraform import aws_subnet.private[0] subnet-abcd1234
 # Or use import blocks (1.5+)
 # In .tf file:
 # import { to = aws_vpc.main, id = "vpc-12345678" }
+# Note: File must not exist — Terraform refuses to overwrite.
 terraform plan -generate-config-out=imported.tf
 ```
 

--- a/skills/terraform-skill/references/quick-reference.md
+++ b/skills/terraform-skill/references/quick-reference.md
@@ -530,12 +530,13 @@ tests/
 
 ### From Terraform → OpenTofu
 
-**Good news:** OpenTofu is a drop-in replacement!
+**Good news:** OpenTofu is a drop-in replacement for Terraform ≤1.5.x; a feature-compatible fork thereafter with divergence on encryption, mock providers, provider functions, and other post-1.6 additions. See the [Terraform vs OpenTofu Comparison](#terraform-vs-opentofu-comparison) above and verify specific feature availability per version.
 
-1. **No code changes needed**
-   - All Terraform syntax works
+1. **No code changes needed for ≤1.5.x syntax**
+   - Terraform ≤1.5.x syntax works as-is
    - Same provider ecosystem
    - Compatible state files
+   - Post-1.6 features (encryption, mock providers, provider functions, etc.) may differ — verify per version
 
 2. **Update CI/CD:**
    ```bash
@@ -626,8 +627,8 @@ Required documentation for all modules:
 | Syntax | Meaning | Use Case |
 |--------|---------|----------|
 | `"5.0.0"` | Exact version | Avoid (inflexible) |
-| `"~> 5.0"` | Pessimistic (5.0.x) | Recommended for stability |
-| `"~> 5.0.1"` | Pessimistic (5.0.x where x >= 1) | Specific patch minimum |
+| `"~> 5.0"` | Pessimistic (>= 5.0, < 6.0 — any 5.x) | Allow minor and patch updates within 5.x |
+| `"~> 5.0.1"` | Pessimistic (>= 5.0.1, < 5.1.0 — 5.0.x patches) | Lock to 5.0.x patch updates only |
 | `">= 5.0, < 6.0"` | Range | Any 5.x version |
 | `">= 5.0"` | Minimum | Risky (breaking changes) |
 

--- a/skills/terraform-skill/references/security-compliance.md
+++ b/skills/terraform-skill/references/security-compliance.md
@@ -26,8 +26,9 @@ This document provides security hardening guidance and compliance automation str
 trivy config .
 checkov -d .
 
-# Compliance testing
-terraform-compliance -f compliance/ -p tfplan.json
+# Compliance testing (policy-as-code against a terraform plan JSON)
+terraform plan -out=tfplan && terraform show -json tfplan > tfplan.json
+conftest test tfplan.json --policy policy/
 ```
 
 ### Trivy Integration

--- a/skills/terraform-skill/references/security-compliance.md
+++ b/skills/terraform-skill/references/security-compliance.md
@@ -48,7 +48,7 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
     scan-ref: '.'
 ```
 
-**Note:** Trivy is the successor to tfsec, maintained by Aqua Security.
+**Note:** Trivy now includes tfsec's rule set; tfsec itself is in maintenance mode since its absorption into Trivy (2022), but still receives maintenance releases. Both are maintained by Aqua Security.
 
 **Example Output:**
 
@@ -107,6 +107,16 @@ resource "aws_db_instance" "this" {
 }
 ```
 
+<a id="secret-string-state-caveat"></a>
+
+> **Note — data source `secret_string` persists to state:** The `aws_secretsmanager_secret_version` data source reads `secret_string` into Terraform state during refresh. `password_wo` (AWS provider v5.71+, Terraform 1.11+) keeps the **resource argument** out of state, but the data source still persists the value. For true state exclusion:
+>
+> - Prefer `manage_master_user_password = true` (AWS-managed, for RDS)
+> - Use `ephemeral` providers/resources (Terraform 1.10+)
+> - Inject via CI environment variable outside Terraform
+>
+> Examples below use the data-source pattern; apply one of the alternatives above when the value must not land in state.
+
 ### ❌ DON'T: Use Default VPC
 
 ```hcl
@@ -162,15 +172,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
 }
 ```
 
+> **SSE-S3 vs SSE-KMS:** `AES256` above is SSE-S3 (AWS-managed key, no per-request audit trail in CloudTrail). For regulated workloads (HIPAA/PCI/FedRAMP), prefer `aws:kms` with a customer-managed CMK + key rotation enabled.
+
 ### ❌ DON'T: Open Security Groups to Internet
 
 ```hcl
-# BAD: Security group open to internet
+# BAD: Security group open to internet on all protocols
 resource "aws_security_group_rule" "allow_all" {
   type              = "ingress"
   from_port         = 0
-  to_port           = 65535
-  protocol          = "tcp"
+  to_port           = 0
+  protocol          = "-1"            # ❌ All protocols (worst case)
   cidr_blocks       = ["0.0.0.0/0"]  # ❌ Never do this
   security_group_id = aws_security_group.this.id
 }
@@ -276,41 +288,17 @@ resource "aws_security_group_rule" "web_https_ingress" {
 
 ## Compliance Testing
 
-### terraform-compliance
+### Policy-as-code for Terraform plans
 
-**Install:**
-
-```bash
-pip install terraform-compliance
-```
-
-**Example Compliance Test:**
-
-```gherkin
-# compliance/aws-encryption.feature
-Feature: AWS Resources must be encrypted
-
-  Scenario: S3 buckets must have encryption
-    Given I have aws_s3_bucket defined
-    When it has aws_s3_bucket_server_side_encryption_configuration
-    Then it must contain rule
-    And it must contain apply_server_side_encryption_by_default
-
-  Scenario: RDS instances must be encrypted
-    Given I have aws_db_instance defined
-    Then it must contain storage_encrypted
-    And its value must be true
-```
-
-**Run Tests:**
+Generate a plan JSON and evaluate it with a policy engine. The modern, actively-maintained options are Conftest (OPA/Rego) and Open Policy Agent directly. The `terraform-compliance` BDD project is archived and no longer maintained; prefer Conftest/OPA for new work.
 
 ```bash
-# Generate plan in JSON
+# Generate plan JSON
 terraform plan -out=tfplan
 terraform show -json tfplan > tfplan.json
 
-# Run compliance tests
-terraform-compliance -f compliance/ -p tfplan.json
+# Evaluate with Conftest (OPA under the hood)
+conftest test tfplan.json --policy policy/
 ```
 
 ### Open Policy Agent (OPA)
@@ -319,12 +307,46 @@ terraform-compliance -f compliance/ -p tfplan.json
 # policy/s3_encryption.rego
 package terraform.s3
 
-deny[msg] {
-  resource := input.resource_changes[_]
-  resource.type == "aws_s3_bucket"
-  not resource.change.after.server_side_encryption_configuration
+# AWS provider v4+ moved S3 encryption to the separate
+# aws_s3_bucket_server_side_encryption_configuration resource.
+# Iterate those resources and verify the rule block sets an accepted algorithm.
 
-  msg := sprintf("S3 bucket '%s' must have encryption enabled", [resource.address])
+valid_algorithms := {"aws:kms", "aws:kms:dsse", "AES256"}
+
+# Collect buckets that have an encryption config with a valid algorithm
+encrypted_buckets[bucket] {
+  sse := input.resource_changes[_]
+  sse.type == "aws_s3_bucket_server_side_encryption_configuration"
+  rule := sse.change.after.rule[_]
+  algo := rule.apply_server_side_encryption_by_default[_].sse_algorithm
+  valid_algorithms[algo]
+  bucket := sse.change.after.bucket
+}
+
+deny[msg] {
+  sse := input.resource_changes[_]
+  sse.type == "aws_s3_bucket_server_side_encryption_configuration"
+  rule := sse.change.after.rule[_]
+  algo := rule.apply_server_side_encryption_by_default[_].sse_algorithm
+  not valid_algorithms[algo]
+
+  msg := sprintf(
+    "S3 encryption config '%s' uses unsupported sse_algorithm '%s' (expected aws:kms or AES256)",
+    [sse.address, algo],
+  )
+}
+
+# Flag buckets that have no matching encryption configuration at all.
+deny[msg] {
+  bucket := input.resource_changes[_]
+  bucket.type == "aws_s3_bucket"
+  bucket_name := bucket.change.after.bucket
+  not encrypted_buckets[bucket_name]
+
+  msg := sprintf(
+    "S3 bucket '%s' has no aws_s3_bucket_server_side_encryption_configuration",
+    [bucket.address],
+  )
 }
 ```
 
@@ -334,35 +356,41 @@ deny[msg] {
 
 ### AWS Secrets Manager Pattern
 
+See the [data-source `secret_string` persistence caveat](#secret-string-state-caveat) above — both `random_password.result` and data-source reads of `secret_string` land in Terraform state. The recommended RDS pattern avoids both.
+
 ```hcl
-# Create secret
-resource "aws_secretsmanager_secret" "db_password" {
-  name        = "prod/database/password"
-  description = "RDS master password"
-
-  recovery_window_in_days = 30
-}
-
-resource "aws_secretsmanager_secret_version" "db_password" {
-  secret_id     = aws_secretsmanager_secret.db_password.id
-  secret_string = random_password.db_password.result
-}
-
-# Generate secure password
-resource "random_password" "db_password" {
-  length  = 32
-  special = true
-}
-
-# Use secret in RDS
-data "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = aws_secretsmanager_secret.db_password.id
+# Recommended: let RDS generate and manage the master password in Secrets Manager
+resource "aws_kms_key" "db" {
+  description             = "KMS CMK for RDS-managed master password"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
 }
 
 resource "aws_db_instance" "this" {
-  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+  # Option 1 (recommended): AWS-managed master password in Secrets Manager
+  manage_master_user_password   = true
+  master_user_secret_kms_key_id = aws_kms_key.db.arn
+
+  # Option 2 (Terraform 1.11+ + AWS provider v5.71+): write-only password
+  # password_wo         = ephemeral.random_password.db.result
+  # password_wo_version = 1
   # ...
 }
+```
+
+If you need a manually-managed secret for a non-RDS consumer, keep the value out of state by sourcing it outside Terraform (CI env var, ephemeral resource, or a write-only argument) rather than via `random_password` + a `data` lookup:
+
+```hcl
+# Only use this shape when the consumer cannot use manage_master_user_password
+# and you are comfortable with the caveat linked above.
+resource "aws_secretsmanager_secret" "app_api_key" {
+  name                    = "prod/app/api-key"
+  description             = "Third-party API key"
+  recovery_window_in_days = 30
+}
+
+# secret_string populated out-of-band (console, CLI, or a write-only argument on
+# providers that support it) — not via random_password stored in state.
 ```
 
 ### Environment Variables
@@ -392,14 +420,17 @@ secrets/
 # backend.tf
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"
-    encrypt        = true  # ✅ Always enable encryption
+    bucket       = "my-terraform-state"
+    key          = "prod/vpc/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true                                             # Enables SSE on PUT
+    kms_key_id   = "arn:aws:kms:us-east-1:ACCOUNT:key/KEY-ID"       # Customer-managed CMK
+    use_lockfile = true                                             # Terraform 1.10+
   }
 }
 ```
+
+> **`encrypt = true` alone is SSE-S3 (AWS-managed AES-256 key, no per-request CloudTrail audit trail).** State often holds secrets, so pair `encrypt = true` with `kms_key_id` pointing at a customer-managed CMK. `use_lockfile = true` (Terraform 1.10+) replaces the need for a DynamoDB lock table.
 
 ### Secure State Bucket
 
@@ -417,16 +448,27 @@ resource "aws_s3_bucket_versioning" "terraform_state" {
   }
 }
 
-# Enable encryption
+# Enable encryption — customer-managed KMS CMK with bucket key to control request costs
+resource "aws_kms_key" "terraform_state" {
+  description             = "KMS CMK for Terraform state bucket"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.terraform_state.arn
     }
+    bucket_key_enabled = true
   }
 }
+
+# Note: for regulated workloads (HIPAA/PCI/FedRAMP), customer-managed KMS with
+# rotation enabled is typically required — SSE-S3 (AES256) is usually insufficient.
 
 # Block public access
 resource "aws_s3_bucket_public_access_block" "terraform_state" {
@@ -446,23 +488,50 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AllowListBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:role/TerraformRole"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::my-terraform-state"
+    },
+    {
+      "Sid": "AllowObjectRW",
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::123456789012:role/TerraformRole"
       },
       "Action": [
-        "s3:ListBucket",
         "s3:GetObject",
-        "s3:PutObject"
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObjectVersion"
       ],
+      "Resource": "arn:aws:s3:::my-terraform-state/*"
+    },
+    {
+      "Sid": "DenyInsecureTransport",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::my-terraform-state",
         "arn:aws:s3:::my-terraform-state/*"
-      ]
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
     }
   ]
 }
 ```
+
+- `s3:ListBucket` must target the bucket ARN; object actions must target `/*` — splitting avoids IAM silently no-op'ing the mismatched pairings.
+- `s3:DeleteObject` + `s3:GetObjectVersion` are required to rotate state objects when versioning is enabled.
+- The `Deny` statement enforces TLS — any HTTP request is rejected regardless of other grants.
 
 ---
 
@@ -518,7 +587,7 @@ resource "aws_iam_policy" "bad_policy" {
 - [ ] Encryption in transit (TLS/SSL)
 - [ ] IAM policies follow least privilege
 - [ ] Logging enabled for all resources
-- [ ] MFA required for privileged access
+- [ ] MFA required for privileged access (enforced at org/IdP level, not per-resource)
 - [ ] Regular security scanning in CI/CD
 
 ### HIPAA Compliance
@@ -558,8 +627,8 @@ Common model mistakes to correct before returning security/compliance recommenda
 
 - [Trivy Documentation](https://aquasecurity.github.io/trivy/)
 - [Checkov Documentation](https://www.checkov.io/)
-- [terraform-compliance](https://terraform-compliance.com/)
 - [Open Policy Agent](https://www.openpolicyagent.org/)
+- [Conftest](https://www.conftest.dev/)
 - [AWS Security Best Practices](https://aws.amazon.com/security/best-practices/)
 
 ---

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -51,7 +51,7 @@ terraform {
     key          = "prod/vpc/terraform.tfstate"
     region       = "us-east-1"
     encrypt      = true
-    use_lock_file = true  # Native S3 locking (Terraform 1.11+)
+    use_lockfile = true  # Native S3 locking (Terraform 1.11+)
     
     # Optional but recommended
     kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
@@ -90,7 +90,7 @@ terraform {
 - Existing infrastructure already using DynamoDB
 - Need DynamoDB for other purposes
 
-**Migration note:** Existing setups using DynamoDB will continue to work. The `use_lock_file` option is opt-in.
+**Migration note:** Existing setups using DynamoDB will continue to work. The `use_lockfile` option is opt-in.
 
 **Backend infrastructure setup (Terraform 1.11+ with lock-file):**
 
@@ -259,9 +259,11 @@ terraform {
   backend "gcs" {
     bucket = "my-terraform-state"
     prefix = "prod/vpc"
-    
-    # Optional: Customer-managed encryption key
-    encryption_key = "projects/my-project/locations/us-central1/keyRings/terraform/cryptoKeys/state"
+
+    # For customer-managed encryption, configure the bucket itself with
+    # `default_kms_key_name` (see bootstrap below) rather than the backend.
+    # The backend's `encryption_key` attribute is for CSEK (a base64-encoded
+    # 32-byte AES-256 key), NOT a Cloud KMS resource name.
   }
 }
 ```
@@ -442,7 +444,7 @@ terraform {
     key          = "prod/terraform.tfstate"
     region       = "us-east-1"
     encrypt      = true
-    use_lock_file = true  # Enable native S3 locking
+    use_lockfile = true  # Enable native S3 locking
   }
 }
 ```
@@ -452,7 +454,7 @@ terraform {
 - ✅ Lower cost (no DynamoDB charges)
 - ✅ Unified management (state + locks in one bucket)
 
-**Migration from DynamoDB:** Simply add `use_lock_file = true` and remove `dynamodb_table`. Both can coexist during migration.
+**Migration from DynamoDB:** Set both `dynamodb_table` and `use_lockfile = true` during Terraform 1.10+ migration — locks acquire via both mechanisms. Once every workflow runs on 1.10+, remove `dynamodb_table`.
 
 ### DynamoDB Locking for S3 (Pre-1.11 or Legacy)
 
@@ -471,7 +473,11 @@ terraform plan
 # Another user attempts operation
 terraform apply
 # Sees: Error acquiring the state lock
-# Wait time: 0s (fails immediately)
+# Default behavior: Terraform retries with backoff until the lock is released
+# or roughly 9 minutes elapse, then fails.
+# Override with -lock-timeout=<duration>, e.g.:
+#   terraform apply -lock-timeout=5m
+# Use -lock-timeout=0s to fail immediately without retry.
 ```
 
 **View current locks:**
@@ -690,6 +696,7 @@ terraform {
     {
       "Effect": "Allow",
       "Action": [
+        "dynamodb:DescribeTable",
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "dynamodb:DeleteItem"
@@ -699,6 +706,7 @@ terraform {
     {
       "Effect": "Allow",
       "Action": [
+        "kms:DescribeKey",
         "kms:Decrypt",
         "kms:Encrypt",
         "kms:GenerateDataKey"
@@ -824,6 +832,12 @@ data "aws_secretsmanager_secret_version" "db_password" {
 }
 ```
 
+> **Caveat:** Reading a secret through `data "aws_secretsmanager_secret_version"`
+> pulls `secret_string` into the state file on every refresh. If the goal is to
+> keep the raw secret out of state, use an `ephemeral` resource/data source
+> (Terraform 1.10+), `manage_master_user_password`, or inject the value via a
+> CI-only environment variable instead of a data source.
+
 #### ✅ DO: Reference External Secrets
 
 ```hcl
@@ -838,10 +852,16 @@ resource "aws_db_instance" "this" {
 }
 ```
 
-#### Best Practice: Rotate Secrets Stored in State
+> **Caveat:** The data source writes `secret_string` into state on every refresh,
+> so this pattern avoids hardcoding — it does not exclude the secret from state.
+> For true state exclusion, use an `ephemeral` resource/data source
+> (Terraform 1.10+), `manage_master_user_password`, or a CI-injected env var.
+
+#### Best Practice: Reconcile State After External Secret Rotation
 
 ```bash
-# After rotation, refresh state
+# After rotation (handled outside Terraform), refresh state so it reflects
+# the new value. This does not rotate the secret itself.
 terraform apply -refresh-only
 ```
 
@@ -876,21 +896,9 @@ resource "aws_cloudtrail" "terraform_state" {
 
 **Azure Storage logging:**
 
-```hcl
-resource "azurerm_storage_account" "terraform_state" {
-  # ... other config ...
-
-  blob_properties {
-    logging {
-      delete                = true
-      read                  = true
-      write                 = true
-      version               = true
-      retention_policy_days = 90
-    }
-  }
-}
-```
+`azurerm_storage_account.blob_properties` does NOT expose a `logging` sub-block.
+Configure blob-service audit logs via `azurerm_monitor_diagnostic_setting`
+targeting the storage account's `blobServices` resource.
 
 **What to monitor:**
 - Who accessed state files
@@ -961,13 +969,18 @@ git commit -m "Migrate state to S3 backend"
 
 #### S3 → Terraform Cloud Migration
 
-**Step 1: Create Terraform Cloud workspace**
+**Step 1: Authenticate to Terraform Cloud**
 
 ```bash
-# Via CLI
+# Authenticate the CLI
 terraform login
-terraform workspace new prod-infrastructure
 ```
+
+The Terraform Cloud workspace is created automatically on first `terraform init`
+against the `cloud {}` block below (provided the org permits auto-creation).
+Alternatively, pre-create it in the TFC UI or with the `tfe_workspace` resource.
+Do NOT use `terraform workspace new` here — CLI workspaces are a different
+concept from Terraform Cloud workspaces.
 
 **Step 2: Update backend config**
 
@@ -1413,7 +1426,7 @@ resource "aws_instance" "app" {
 - Critical infrastructure vs experimental features
 
 ✅ **Large state files:**
-- State operations becoming slow (>1000 resources)
+- State operations becoming slow (>1000 resources — rough heuristic, depends on provider refresh time)
 
 ✅ **Independent deployment cadence:**
 - Database needs weekly updates
@@ -1439,7 +1452,7 @@ resource "aws_instance" "app" {
 | Factor | Split State | Single State |
 |--------|-------------|--------------|
 | **Team size** | Multiple teams | Single team |
-| **Resource count** | >500 resources | <100 resources |
+| **Resource count** | >500 resources | <100 resources (rough heuristics — depends on provider refresh time) |
 | **Update frequency** | Different cadences | Same cadence |
 | **Risk tolerance** | Low (production) | High (dev/test) |
 | **Coupling** | Loosely coupled | Tightly coupled |
@@ -1602,7 +1615,7 @@ terraform {
 **Detect drift:**
 
 ```bash
-# Terraform 1.5+
+# Terraform 0.15.4+
 terraform plan -refresh-only
 
 # Shows what's changed in infrastructure vs state
@@ -1628,7 +1641,7 @@ terraform apply  # Updates state
 **Prevent drift:**
 - ✅ Use CloudTrail to monitor manual changes
 - ✅ Implement policy to block manual changes
-- ✅ Use drift detection tools (Terraform Cloud, checkov)
+- ✅ Use drift detection tools (Terraform Cloud drift detection, driftctl)
 - ✅ Regular `terraform plan` in CI/CD
 - ✅ Enable termination protection on critical resources
 

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -39,7 +39,7 @@ This document provides detailed guidance on state management, from remote backen
 
 ### AWS S3 Backend (Recommended)
 
-#### S3 with Native Lock-File (Terraform 1.11+, Recommended)
+#### S3 with Native Lock-File (Terraform 1.10+, Recommended)
 
 **Simplest setup - no DynamoDB required:**
 
@@ -51,7 +51,7 @@ terraform {
     key          = "prod/vpc/terraform.tfstate"
     region       = "us-east-1"
     encrypt      = true
-    use_lockfile = true  # Native S3 locking (Terraform 1.11+)
+    use_lockfile = true  # Native S3 locking (Terraform 1.10+)
     
     # Optional but recommended
     kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
@@ -65,7 +65,7 @@ terraform {
 - ✅ Simpler infrastructure (one less resource to manage)
 - ✅ Lock files stored alongside state in same bucket
 
-#### S3 with DynamoDB Locking (Pre-1.11 or Legacy)
+#### S3 with DynamoDB Locking (Pre-1.10 or Legacy)
 
 **Complete setup with DynamoDB:**
 
@@ -86,13 +86,13 @@ terraform {
 ```
 
 **When to use DynamoDB locking:**
-- Terraform versions < 1.11
+- Terraform versions < 1.10
 - Existing infrastructure already using DynamoDB
 - Need DynamoDB for other purposes
 
 **Migration note:** Existing setups using DynamoDB will continue to work. The `use_lockfile` option is opt-in.
 
-**Backend infrastructure setup (Terraform 1.11+ with lock-file):**
+**Backend infrastructure setup (Terraform 1.10+ with lock-file):**
 
 ```hcl
 # bootstrap/main.tf - Run this ONCE to create state backend
@@ -160,7 +160,7 @@ resource "aws_kms_alias" "terraform_state" {
 }
 ```
 
-**Backend infrastructure setup (Pre-1.11 with DynamoDB):**
+**Backend infrastructure setup (Pre-1.10 with DynamoDB):**
 
 ```hcl
 # If using DynamoDB locking, add this resource to the above configuration:
@@ -418,8 +418,8 @@ Result: Operations are serialized
 
 | Backend | Locking | Lock Mechanism |
 |---------|---------|----------------|
-| **S3** (Terraform 1.11+) | ✅ Native | Lock files |
-| **S3** (Pre-1.11) | ✅ With DynamoDB | DynamoDB table |
+| **S3** (Terraform 1.10+) | ✅ Native | Lock files |
+| **S3** (Pre-1.10) | ✅ With DynamoDB | DynamoDB table |
 | **Azure Storage** | ✅ Native | Blob lease |
 | **GCS** | ✅ Native | Object metadata |
 | **Terraform Cloud** | ✅ Native | Built-in |
@@ -427,7 +427,7 @@ Result: Operations are serialized
 | **Postgres** | ✅ Native | Row locking |
 | **Local** | ❌ None | N/A |
 
-### S3 Native Lock-File (Terraform 1.11+)
+### S3 Native Lock-File (Terraform 1.10+)
 
 **How it works:**
 - Uses regular S3 objects as lock files
@@ -456,7 +456,7 @@ terraform {
 
 **Migration from DynamoDB:** Set both `dynamodb_table` and `use_lockfile = true` during Terraform 1.10+ migration — locks acquire via both mechanisms. Once every workflow runs on 1.10+, remove `dynamodb_table`.
 
-### DynamoDB Locking for S3 (Pre-1.11 or Legacy)
+### DynamoDB Locking for S3 (Pre-1.10 or Legacy)
 
 **Lock table attributes:**
 - `LockID` (String, Hash Key) - Must be exactly "LockID"
@@ -473,11 +473,9 @@ terraform plan
 # Another user attempts operation
 terraform apply
 # Sees: Error acquiring the state lock
-# Default behavior: Terraform retries with backoff until the lock is released
-# or roughly 9 minutes elapse, then fails.
-# Override with -lock-timeout=<duration>, e.g.:
+# Default: `-lock-timeout=0s` — fail immediately on lock contention.
+# Set `-lock-timeout=<duration>` (e.g. `5m`) to retry with backoff for the specified window.
 #   terraform apply -lock-timeout=5m
-# Use -lock-timeout=0s to fail immediately without retry.
 ```
 
 **View current locks:**
@@ -1793,7 +1791,7 @@ Common model mistakes to correct before returning state-related recommendations:
 - commits `*.tfstate` to git
 - mixes prod and non-prod in the same backend key
 - recommends workspace-only isolation as a substitute for backend-level IAM separation
-- writes DynamoDB-lock configuration on Terraform 1.11+ instead of using `use_lockfile = true` on the S3 backend
+- writes DynamoDB-lock configuration on Terraform 1.10+ instead of using `use_lockfile = true` on the S3 backend
 - reads via `terraform_remote_state` within a single team's stack instead of using module outputs (see [module-patterns.md](module-patterns.md#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries))
 - omits the rollback/recovery note for destructive state operations
 

--- a/skills/terraform-skill/references/testing-frameworks.md
+++ b/skills/terraform-skill/references/testing-frameworks.md
@@ -97,10 +97,10 @@ run "create_bucket" {
 }
 
 run "verify_encryption" {
-  command = apply  # Set-type `rule` block must be materialized before indexing
+  command = apply  # `rule` is a set; use `one(...)` to extract the singleton
 
   assert {
-    condition     = aws_s3_bucket_server_side_encryption_configuration.main.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
+    condition     = one(aws_s3_bucket_server_side_encryption_configuration.main.rule).apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
     error_message = "Bucket must use AES256 encryption"
   }
 }

--- a/skills/terraform-skill/references/testing-frameworks.md
+++ b/skills/terraform-skill/references/testing-frameworks.md
@@ -3,7 +3,7 @@
 > **Part of:** [terraform-skill](../SKILL.md)
 > **Purpose:** Detailed guides for Terraform/OpenTofu testing frameworks
 
-This document provides in-depth guidance on testing frameworks for Infrastructure as Code. For the decision matrix and high-level overview, see the [main skill file](../SKILL.md#testing-strategy-framework).
+This document provides in-depth guidance on testing frameworks for Infrastructure as Code. For the decision matrix and high-level overview, see the [main skill file](../SKILL.md#testing-strategy).
 
 ---
 
@@ -83,6 +83,8 @@ terraform show -json tfplan | jq '.'
 
 ### Basic Structure
 
+> **Test discovery:** `terraform test` finds `*.tftest.hcl` files under `tests/` relative to the module root. Use `-filter=<path>` to scope to a specific file.
+
 ```hcl
 # tests/s3_bucket.tftest.hcl
 run "create_bucket" {
@@ -95,7 +97,7 @@ run "create_bucket" {
 }
 
 run "verify_encryption" {
-  command = plan
+  command = apply  # Set-type `rule` block must be materialized before indexing
 
   assert {
     condition     = aws_s3_bucket_server_side_encryption_configuration.main.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
@@ -135,7 +137,7 @@ mcp__terraform__get_provider_details({
 |--------------|------------|----------|
 | `rule` in `aws_s3_bucket_server_side_encryption_configuration` | **set** | ❌ Cannot use `[0]` |
 | `transition` in `aws_s3_bucket_lifecycle_configuration` | **set** | ❌ Cannot use `[0]` |
-| `noncurrent_version_expiration` in lifecycle | **list** | ✅ Can use `[0]` |
+| `noncurrent_version_expiration` in lifecycle | **nested block (MaxItems=1)** — list-of-1 | ✅ Can use `[0]` |
 
 ### Working with Set-Type Blocks
 
@@ -417,7 +419,7 @@ run "verify_lifecycle_transitions" {
   assert {
     # Check that both transitions exist using for expression
     condition = length([
-      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
       rule.id if rule.id == "archive"
     ]) == 1
     error_message = "Lifecycle rule should exist"
@@ -426,7 +428,7 @@ run "verify_lifecycle_transitions" {
   assert {
     # Verify transition count using length
     condition = alltrue([
-      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
       length(rule.transition) == 2
     ])
     error_message = "Should have 2 transitions"
@@ -454,6 +456,7 @@ package test
 
 import (
     "testing"
+    "github.com/gruntwork-io/terratest/modules/random"
     "github.com/gruntwork-io/terratest/modules/terraform"
     "github.com/stretchr/testify/assert"
 )
@@ -464,7 +467,7 @@ func TestS3Module(t *testing.T) {
     terraformOptions := &terraform.Options{
         TerraformDir: "../examples/complete",
         Vars: map[string]interface{}{
-            "bucket_name": "test-bucket-" + uniqueId(),
+            "bucket_name": "test-bucket-" + random.UniqueId(),
         },
     }
 
@@ -547,7 +550,7 @@ stage(t, "teardown", func() {
 Quick syntax check? → terraform validate + fmt
 Security scan? → trivy + checkov
 Terraform 1.6+, simple logic? → Native tests
-Pre-1.6, or complex integration? → Terratest
+Complex integration or multi-cloud orchestration? → Terratest
 ```
 
 ### Cost Optimization


### PR DESCRIPTION
## Summary

Factual-correctness fixes surfaced by a 7-reviewer expert panel (5 Claude personas — Terraform, Security, DevOps, SRE, Cloud — plus GPT Codex + Gemini, all independent, no cross-contamination). 2 commits: initial tier A+B+C+D pass, then a second cross-review found 7 residual issues that were also fixed.

## Scope

All 8 reference files in the skill touched. **Did not re-review** content already fact-checked in PR #17 (April refactor), PR #18 (Provider Removal), PR #19 (LLM Consumption Rules), PR #20 (hallucination guards + factual fixes). Scope was the remaining 90 %+ of file content.

## Fixes by severity

### Schema / syntax (would fail plan/apply)

- \`use_lock_file\` typo eradicated across \`state-management.md\` (correct: \`use_lockfile\`)
- S3 native lock-file version floor \`1.11+\` → \`1.10+\` in 14 places (SKILL.md + state-management.md)
- GCS backend \`encryption_key\` misuse (CSEK vs KMS) — dropped in favour of bucket-level \`default_kms_key_name\`
- TFC workspace creation via \`terraform workspace new\` replaced with init-against-\`cloud{}\`-block (CLI workspace ≠ TFC workspace)
- \`-refresh-only\` version floor \`1.5+\` → \`0.15.4+\`
- Azure \`blob_properties.logging\` block removed (invalid schema); pointed to \`azurerm_monitor_diagnostic_setting\`
- State IAM policy missing \`kms:DescribeKey\` + \`dynamodb:DescribeTable\` (called during \`init\`)
- Lock-timeout default corrected: fail-immediately (\`0s\`), opt into retry via \`-lock-timeout=<duration>\` — verified via \`terraform plan -help\`
- \`provider::aws::arn_build\` signature corrected to 5 args \`(partition, service, region, account_id, resource)\`
- \`~> 5.0\` comment semantics corrected: allows any 5.x minor, not just 5.0.x patches (in code-patterns + quick-reference)
- Legacy splat \`.*.id\` → \`[*].id\`
- Atlantis \`extra_args: ["-lock=false"]\` (single arg, not two)
- Cleanup script JMESPath \`Value<\` was always-false; rewrote with jq + \`fromdateiso8601\` post-filter
- Testing-frameworks broken anchor \`#testing-strategy-framework\` → \`#testing-strategy\`
- Set-indexing contradiction: \`rule[0]...\` with \`command = apply\` still invalid (sets unordered); switched to \`one(...)\` for singleton set
- Module-patterns S3 backend example now 1.10+-first; pre-1.10 DynamoDB kept as inline fallback

### Security

- OPA rule rewritten to target \`aws_s3_bucket_server_side_encryption_configuration\` (AWS provider v4+ separate resource; the previous rule always denied because provider removed inline encryption)
- State bucket IAM split into 3 statements: \`ListBucket\` / object R/W incl. \`DeleteObject\` + \`GetObjectVersion\` / explicit \`Deny\` on \`aws:SecureTransport = false\`
- \`aws_db_instance.password\` example replaced with \`manage_master_user_password = true\` + CMK; \`password_wo\` shown as Option 2
- Data-source \`secret_string\` persistence caveat: \`aws_secretsmanager_secret_version\` reads \`secret_string\` into state on refresh; \`password_wo\` only keeps the resource argument out. Recommend \`manage_master_user_password\`, \`ephemeral\` (1.10+), or CI env var injection
- Backend examples now use \`kms_key_id\` with customer-managed CMK + \`bucket_key_enabled = true\`
- \`terraform-compliance\` (archived 2023) replaced with Conftest/OPA pointer
- SSE-S3 vs SSE-KMS caveat added for HIPAA/PCI/FedRAMP workloads

### Process / imprecise claims

- MFA checklist annotated as IdP/SCP-level, not per-resource
- Trivy/tfsec successor claim softened
- GitLab \`only:\` → \`rules:\` syntax
- TFLint install switched to \`terraform-linters/setup-tflint@v4\` (pinned)
- \`trivy-action\`, \`checkov-action\` pinned (no \`@master\`)
- \`actions/setup-go@v4\` → \`@v5\`; \`go-version: 'stable'\`
- \`TF_PLUGIN_CACHE_DIR: \${{ runner.temp }}/terraform-plugin-cache\` (\`~\` inside quoted shell doesn't expand)
- \`on: [push, pull_request]\` refactored to \`push.branches: [main]\` + \`pull_request\` to avoid duplicate PR runs
- Atlantis \`terraform_version\` bumped \`v1.6.0\` → \`1.12.0\`
- \`noncurrent_version_expiration\` relabeled MaxItems=1 nested block (not plain list)
- \`[0]\` indexing removed where resource lacks \`count\`/\`for_each\`
- Terratest \`uniqueId()\` → \`random.UniqueId()\` + missing import
- \"Pre-1.6 / Go expertise\" framing updated to \"complex integration or multi-cloud\" (1.6 is baseline)
- Added test-file discovery note (\`tests/*.tftest.hcl\` + \`-filter=<path>\`)
- \`checkov\` removed from drift-detection context (static scanner, not drift detector); replaced with \`driftctl\`
- \"Rotate Secrets\" heading renamed to \"Reconcile State After External Secret Rotation\"
- Resource-count thresholds labeled as rough heuristics
- Provider-defined functions row notes provider must declare them
- Cross-variable validation row clarifies scope
- Module \`aws\` provider version \`>= 6.0\` → \`~> 5.0\` (internal consistency with protected PR #20 subsection)

### Polish

- OpenTofu \"drop-in replacement\" claim qualified with post-1.6 divergence caveat (both comparison table and migration section)
- \"BSL 1.1\" → \"BUSL-1.1\" (SPDX-correct)
- \`force-unlock -force\` CI-friendly variant noted
- \`-generate-config-out\` must-not-exist note
- OpenTofu 1.6 row trivial claim replaced with concrete additions

## NOT fixed (intentional)

- \"Terraform 1.14+ latest-version claim\" — confirmed by maintainer as current release.

## Process

Per CLAUDE.md §LLM Consumption Rules, every fix preserves retrieval-first ordering and decision-table-before-playbook structure. SKILL.md anchor integrity maintained (all \`#heading\` references still resolve).

Full findings report: \`docs/verification/2026-04-22-expert-panel-findings.md\` (gitignored).

## Test plan

- [ ] \`rg \"use_lock_file\" skills/\` returns 0 matches
- [ ] \`rg \"1\\.11\\+\" skills/terraform-skill/SKILL.md\` — remaining matches only reference \`write_only\`
- [ ] \`rg \"@master\" skills/terraform-skill/references/ci-cd-workflows.md\` returns 0 matches
- [ ] \`validate.yml\` passes (frontmatter, size, link check, markdownlint)
- [ ] OPA rule in security-compliance.md matches \`aws_s3_bucket_server_side_encryption_configuration\` under current AWS provider v5+/v6+
- [ ] All JSON in \`security-compliance.md\` parses (trust policy, IAM policy)
- [ ] All YAML blocks in \`ci-cd-workflows.md\` parse
- [ ] Testing-frameworks anchor \`../SKILL.md#testing-strategy\` resolves
- [ ] SKILL.md routing table anchors all resolve to real \`### Heading\`s