### PR TITLE
docs: Claude Code terraform-ls install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ Terraform language server.
   [terraform-ls releases](https://github.com/hashicorp/terraform-ls/releases)
   page, or turn it on through your editor or agent host. Use whatever version
   your host supports.
+  - Claude Code: install it as an LSP plugin -
+    `/plugin marketplace add boostvolt/claude-code-lsps` then
+    `/plugin install terraform-ls@claude-code-lsps`.
 
 How the skill uses it:
 


### PR DESCRIPTION
Adds the Claude Code LSP-plugin install route (`boostvolt/claude-code-lsps` -> `terraform-ls@claude-code-lsps`) under README `## Code intelligence (optional)` > Install. Previously only the upstream binary / generic host path was documented. README-only; terraform-ls setup belongs in the README, not SKILL.md/references (human/setup, token discipline).