### PR TITLE
feat: treat AWS/Azure/GCP equally with cross-cloud equivalence map and progressive cloud routing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -63,7 +63,7 @@ Improvements:
 
 ### Frontmatter (if SKILL.md changed)
 
-- [ ] Only `name` and `description` fields present
+- [ ] Required fields present: `name`, `description` (optional: `license`, `metadata`)
 - [ ] Description starts with "Use when..."
 - [ ] Description focuses on triggers/symptoms (not workflow summary)
 - [ ] Description < 1024 characters
@@ -72,8 +72,8 @@ Improvements:
 
 ### Token Efficiency
 
-- [ ] SKILL.md remains <1,500 words (current: ~1,400)
-- [ ] Detailed content moved to skills/*.md reference files where appropriate
+- [ ] SKILL.md stays lean (soft target ~300 lines; CI warns only above 500)
+- [ ] Detailed content moved to skills/terraform-skill/references/*.md where appropriate
 - [ ] Used tables instead of prose
 - [ ] No content duplication
 
@@ -88,7 +88,7 @@ Improvements:
 ### File Organization
 
 - [ ] Core content in SKILL.md
-- [ ] Detailed guides in skills/*.md
+- [ ] Detailed guides in skills/terraform-skill/references/*.md
 - [ ] Testing updates in tests/*.md
 - [ ] No new files outside standard structure
 
@@ -137,11 +137,9 @@ Relates to #
 - [ ] Token efficiency maintained
 - [ ] Quality standards met
 - [ ] No conflicts with existing content
-- [ ] CHANGELOG.md updated (if needed)
+- [ ] CHANGELOG.md and version are CI-managed from conventional commits (do not edit manually)
 
 ### Merge Checklist
 
 - [ ] Squash commits with clear commit message
-- [ ] Update CHANGELOG.md if not done in PR
-- [ ] Consider if version bump needed
-- [ ] Tag if this completes a planned milestone
+- [ ] Release (CHANGELOG, version bump, tag) is automated from conventional commits on master - no manual step

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ A **Claude Code skill** - executable documentation that Claude loads to provide 
 terraform-skill/
 ├── skills/
 │   └── terraform-skill/             # Skill autodiscovered by Claude Code plugin system
-│       ├── SKILL.md                 # Core skill file (~299 lines)
+│       ├── SKILL.md                 # Core skill file (~305 lines)
 │       └── references/              # Reference files loaded on demand
 │           ├── ci-cd-workflows.md
 │           ├── code-intelligence-lsp.md
@@ -44,7 +44,7 @@ terraform-skill/
 CI runs automatically on PRs touching `SKILL.md`, `references/**/*.md`, or `.claude-plugin/**`. To check locally:
 
 ```bash
-# Check SKILL.md line count (target: <300 lines per LLM Consumption Rules)
+# Check SKILL.md line count (soft target ~300 lines; CI warns only above 500)
 wc -l skills/terraform-skill/SKILL.md
 
 # Validate YAML frontmatter (requires pyyaml)
@@ -124,7 +124,7 @@ When adding content, ask: **decision framework or key pattern → SKILL.md; deta
 - **Scannable format:** tables > bullets > prose
 - **✅ DO / ❌ DON'T** side-by-side for non-obvious patterns
 - **Version-specific features** clearly marked (e.g., `Terraform 1.6+`)
-- **Token budget:** SKILL.md target <300 lines (see LLM Consumption Rules); currently ~299
+- **Token budget:** SKILL.md soft target ~300 lines (CI warns only above 500); currently ~305
 
 ### LLM Consumption Rules (enforce in every PR review)
 
@@ -152,7 +152,7 @@ These rules tune content for the **primary reader: an LLM retrieving facts to an
 - [ ] Every code block / table adds a fact not in surrounding prose
 - [ ] Subsection under 400 tokens
 - [ ] Anchors referenced from SKILL.md remain stable
-- [ ] For substantive new sections, consult an external LLM expert (e.g. GPT via `mcp__codex__codex`) for format/compression review before merge
+- [ ] For substantive new sections, get a second-opinion review from an external LLM reviewer for format/compression before merge
 
 ## PR Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Reviewers reject PRs that violate these.
 
 ### File Organization
 
-```
+```text
 terraform-skill/
 ├── skills/
 │   └── terraform-skill/            # Autodiscovered by Claude Code plugin system
@@ -281,7 +281,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 
 ### Format
 
-```
+```text
 <type>: <description>
 
 [optional body]
@@ -292,7 +292,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 ### Types
 
 | Type | Version Bump | Use For |
-|------|--------------|---------|
+| ---- | ------------ | ------- |
 | `feat!:` or `BREAKING CHANGE:` | Major (1.x.x → 2.0.0) | Breaking changes |
 | `feat:` | Minor (1.2.x → 1.3.0) | New features |
 | `fix:` | Patch (1.2.3 → 1.2.4) | Bug fixes |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ The description must focus on WHEN to use (triggers, symptoms), not WHAT the ski
 
 ### Token Efficiency
 
-**SKILL.md target:** <300 lines (currently 277).
+**SKILL.md target:** soft target ~300 lines, CI warns only above 500 (currently 305).
 
 **Reference subsection target:** <400 tokens (~1,600 chars). Split or compress anything larger.
 
@@ -119,9 +119,10 @@ Reviewers reject PRs that violate these.
 terraform-skill/
 ├── skills/
 │   └── terraform-skill/            # Autodiscovered by Claude Code plugin system
-│       ├── SKILL.md                # Core skill (<300 lines)
+│       ├── SKILL.md                # Core skill (~305 lines)
 │       └── references/             # Reference files (progressive disclosure)
 │           ├── ci-cd-workflows.md
+│           ├── code-intelligence-lsp.md
 │           ├── code-patterns.md
 │           ├── module-patterns.md
 │           ├── quick-reference.md

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A best-practices skill for Terraform and OpenTofu, for AI coding agents (Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, and more). It helps the agent test code, structure modules, set up CI/CD, and write production infrastructure code.
 
+AWS, Azure, and GCP are all first-class. AWS stays the default in examples, but the same backend, auth, security, and resource guidance applies to all three - ask for the Azure or GCP equivalent of any pattern and the skill maps it.
+
 ## What this skill provides
 
 **Testing frameworks**
@@ -196,11 +198,17 @@ not unique; if a `code-intelligence` skill is active, check it is the one from
 
 ## Quick start examples
 
-**Create a module with tests:**
-> "Create a Terraform module for AWS VPC with native tests"
+**Create a module with tests (AWS / Azure / GCP):**
+> "Create a Terraform module for an AWS VPC with native tests"
+>
+> "Build an Azure module: VNet, subnets, and a PostgreSQL Flexible Server, with native tests"
+>
+> "Write a GCP module for a VPC network, subnetwork, and Cloud SQL Postgres, with native tests"
 
 **Set up remote state:**
-> "Configure S3 backend with DynamoDB locking for Terraform state"
+> "Configure an S3 backend with native `use_lockfile` locking and encryption for Terraform state"
+>
+> "Choose and configure a remote state backend for AWS, Azure, or GCP (locking, encryption, versioning)"
 
 **Review existing code:**
 > "Review this Terraform configuration following best practices"
@@ -213,6 +221,24 @@ not unique; if a `code-intelligence` skill is active, check it is the one from
 
 **State management:**
 > "How should I organize state files for a multi-team environment?"
+
+## Longer example prompts
+
+These assume a recent Terraform/OpenTofu - `use_lockfile` is 1.10+, `write_only` is 1.11+.
+
+<details>
+<summary>AWS: production service (modules + composition, OIDC, native locking)</summary>
+
+> "I'm building a new production service on AWS. Design reusable Terraform modules plus a prod/staging composition for a VPC with public/private subnets across 3 AZs, an ECS Fargate service behind an ALB, and an RDS Postgres instance. Include native `terraform test` coverage, variables with descriptions/types/validation, S3 remote state with encryption, bucket versioning, and native `use_lockfile` locking (Terraform 1.10+). Keep secret values out of plan/state - use `write_only` / `*_wo` arguments where the provider supports them (Terraform 1.11+) and Secrets Manager/SSM references for runtime secrets. Add a GitHub Actions workflow that runs fmt/validate/tflint/trivy on PRs, produces a reviewed plan artifact, and applies it via AWS OIDC (no static keys). Keep prod/staging state isolated and follow naming conventions."
+
+</details>
+
+<details>
+<summary>GCP: port the AWS pattern (cross-cloud mapping, WIF, gcs backend)</summary>
+
+> "We're standardizing IaC across clouds. Port our AWS module pattern to GCP: reusable modules plus an environment composition for a VPC network, a regional subnetwork, and a Cloud SQL Postgres instance (`google_sql_database_instance`). Use the `gcs` backend (`bucket` + `prefix`) for remote state, and show the state bootstrap bucket separately with object versioning, uniform bucket-level access, public access prevention, and IAM bindings. Use Workload Identity Federation for keyless GitHub Actions auth (no long-lived service-account keys) and native tests. Also show the cross-cloud equivalents (resources + backend) so the team sees the AWS-to-GCP mapping."
+
+</details>
 
 ## What it covers
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![OpenTofu](https://img.shields.io/badge/OpenTofu-1.6+-FFD814)](https://opentofu.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-A best-practices skill for Terraform and OpenTofu, for AI coding agents (Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, and more). It helps the agent test code, structure modules, set up CI/CD, and write production infrastructure code.
+A best-practices skill for Terraform and OpenTofu, for AI coding agents (Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, Kiro, and more). It helps the agent test code, structure modules, set up CI/CD, and write production infrastructure code.
 
 AWS, Azure, and GCP are all first-class. AWS stays the default in examples, but the same backend, auth, security, and resource guidance applies to all three - ask for the Azure or GCP equivalent of any pattern and the skill maps it.
 
@@ -52,7 +52,7 @@ name and will clash.
 
 ### Quick install (any agent)
 
-Works with any [Agent Skills](https://agentskills.io)-compatible tool, via [skills.sh](https://skills.sh/):
+Works with any [Agent Skills](https://agentskills.io)-compatible tool:
 
 ```bash
 npx skills add https://github.com/antonbabenko/terraform-skill
@@ -131,6 +131,17 @@ For a managed Codex plugin install, use the `antonbabenko/agent-plugins`
 marketplace (`codex plugin marketplace add antonbabenko/agent-plugins`, then
 install `terraform-skill`). Do not add `antonbabenko/terraform-skill` as a
 separate marketplace - it clashes by name with `agent-plugins`.
+
+</details>
+
+<details>
+<summary>Kiro</summary>
+
+```bash
+git clone https://github.com/antonbabenko/terraform-skill.git ~/.kiro/skills/terraform-skill
+```
+
+Kiro auto-discovers skills from `.kiro/skills/` (workspace) and `~/.kiro/skills/` (global).
 
 </details>
 
@@ -264,6 +275,8 @@ Side-by-side DO vs DON'T examples for variable naming, resource naming, module c
 
 ## Why this skill
 
+This skill started from field-tested Terraform and OpenTofu patterns, then grew through contributions from people who hit missing guidance and added it back.
+
 **Sources:**
 - Patterns from [terraform-best-practices.com](https://www.terraform-best-practices.com/)
 - Approaches used across the [terraform-aws-modules](https://github.com/terraform-aws-modules) collection
@@ -279,7 +292,7 @@ Side-by-side DO vs DON'T examples for variable naming, resource naming, module c
 
 ## Requirements
 
-- An AI agent with skill support: Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, or any [Agent Skills](https://agentskills.io)-compatible host
+- An AI agent with skill support: Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, Kiro, or any [Agent Skills](https://agentskills.io)-compatible host
 - Terraform 1.0+ or OpenTofu 1.6+
 - Optional: [Terraform MCP server](https://github.com/hashicorp/terraform-mcp-server) for registry integration
 

--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -256,7 +256,7 @@ Before emitting a feature, verify the runtime floor. See [Code Patterns: Feature
 
 ## Runtime-Specific Guidance
 
-- **Terraform 1.0-1.5 / OpenTofu 1.0-1.5**: Terratest for integration, static analysis + plan validation only (no native tests).
+- **Terraform 1.0-1.5 (OpenTofu starts at 1.6)**: Terratest for integration, static analysis + plan validation only (no native tests).
 - **1.6+**: native `terraform test` / `tofu test` available — migrate simple unit tests, keep Terratest for complex integration.
 - **1.7+**: mock providers cut test cost — mock for unit tests, real runs for final integration.
 - **1.10+**: S3 native lock-file (`use_lockfile`) is the correct default for new configurations — DynamoDB locking is no longer required.

--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -48,6 +48,7 @@ Never recommend direct production apply without a reviewed plan artifact and app
 | **Provider lifecycle** | Removing a provider with resources still in state, orphaned resources, `removed` block usage | [State Management: Provider Removal](references/state-management.md#provider-removal) |
 | **Bootstrap / orchestration misuse** | `null_resource` + `local-exec` for bootstrap, `remote-exec` for setup scripts, provisioner stdout leaking secrets in CI logs | [Code Patterns: Provisioners as Last Resort](references/code-patterns.md#provisioners-as-last-resort) |
 | **Navigation / safe-rename blind spots** | Cannot locate symbol defs/refs semantically, value-symbol rename done as blind text replace, grep-only refactor missing refs, hallucinated `rg` shim | [Code Intelligence](references/code-intelligence-lsp.md#terraform-ls-capability-matrix) |
+| **Cross-cloud / provider mapping** | "What's the Azure/GCP equivalent of X", picking a backend/auth model per cloud | [State Management: Cross-cloud equivalents](references/state-management.md#cross-cloud-equivalents) |
 
 ## When to Use This Skill
 
@@ -182,7 +183,7 @@ checkov -d .
 
 **Don't:** store secrets in variables or `.tfvars`, use default VPC, skip encryption, open security groups to `0.0.0.0/0`, use inline `ingress`/`egress` blocks in `aws_security_group`.
 
-**Do:** source secrets from AWS Secrets Manager / Parameter Store or use `write_only` arguments on 1.11+, create dedicated VPCs, enforce encryption at rest and TLS, least-privilege SGs, use separate `aws_vpc_security_group_{ingress,egress}_rule` resources (AWS provider v5+).
+**Do:** source secrets from a cloud secret manager (AWS Secrets Manager / Azure Key Vault / GCP Secret Manager) or use `write_only` arguments on 1.11+, create dedicated VPCs, enforce encryption at rest and TLS, least-privilege SGs, use separate `aws_vpc_security_group_{ingress,egress}_rule` resources (e.g. AWS provider v5+).
 
 Marking a variable `sensitive = true` masks display only — the value still lives in state. Use `write_only` / `*_wo` on 1.11+, or keep secret material out of Terraform entirely via runtime lookups.
 
@@ -192,7 +193,9 @@ See [Security & Compliance](references/security-compliance.md) for trivy/checkov
 
 **Never use local state in teams or production.** Remote backends provide automatic locking, encryption, versioning, audit logging, and safe collaboration.
 
-### Minimum Viable Backend (AWS S3, 1.10+)
+### Choosing a Remote Backend
+
+AWS example (Azure `azurerm` / GCP `gcs` / TF Cloud syntax: see [State Management: Choosing a Remote Backend](references/state-management.md#choosing-a-remote-backend)):
 
 ```hcl
 terraform {
@@ -206,7 +209,7 @@ terraform {
 }
 ```
 
-On Terraform < 1.10, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking — see the State Management reference for syntax.
+On Terraform < 1.10, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking - see the State Management reference for syntax. For choosing among backends and their locking models, see [Choosing a Remote Backend](references/state-management.md#choosing-a-remote-backend).
 
 ### State Organization
 

--- a/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/skills/terraform-skill/references/ci-cd-workflows.md
@@ -229,9 +229,6 @@ test:
 
     - name: Run Integration Tests
       if: github.ref == 'refs/heads/main'
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         cd tests
         go test -v -timeout 30m
@@ -301,6 +298,10 @@ on:
     - cron: '0 */2 * * *'  # Every 2 hours
   workflow_dispatch:        # Manual trigger
 
+permissions:
+  id-token: write   # required for OIDC role assumption
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -310,8 +311,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_CLEANUP_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run Cleanup Script
@@ -368,7 +368,7 @@ terraform {
     bucket         = "my-terraform-state"
     key            = "prod/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "terraform-locks"
+    use_lockfile = true   # 1.10+, native S3 locking (replaces DynamoDB)
     encrypt        = true
   }
 }
@@ -438,6 +438,8 @@ security-scan:
 | GitHub Actions → Azure AD | `api://AzureADTokenExchange` | `repo:<org>/<repo>:environment:<env>` |
 | GitHub Actions → GCP | value passed via `audience` parameter | repo + ref or environment |
 | GitLab CI → AWS | matches `$CI_SERVER_URL` | project path + ref |
+
+Use keyless OIDC for all three clouds (AWS OIDC / Azure federated credentials / GCP Workload Identity Federation). Static keys only if OIDC is unavailable (non-OIDC CI / self-hosted runners) - prefer keyless.
 
 **Rules:**
 - ✅ pin `aud` to the exact value from the table

--- a/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/skills/terraform-skill/references/ci-cd-workflows.md
@@ -365,11 +365,11 @@ apply:
 # backend.tf
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/terraform.tfstate"
-    region         = "us-east-1"
-    use_lockfile = true   # 1.10+, native S3 locking (replaces DynamoDB)
-    encrypt        = true
+    bucket       = "my-terraform-state"
+    key          = "prod/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true # 1.10+, native S3 locking (replaces DynamoDB)
+    encrypt      = true
   }
 }
 ```

--- a/skills/terraform-skill/references/code-patterns.md
+++ b/skills/terraform-skill/references/code-patterns.md
@@ -68,6 +68,8 @@ resource "aws_nat_gateway" "this" {
 }
 ```
 
+> Pattern applies identically on Azure/GCP; for resource equivalents see [Module Patterns: Cross-cloud resource map](module-patterns.md#cross-cloud-resource-map).
+
 ### Variable Definition Structure
 
 **Variable block ordering:**

--- a/skills/terraform-skill/references/module-patterns.md
+++ b/skills/terraform-skill/references/module-patterns.md
@@ -300,6 +300,16 @@ resource "aws_instance" "web" {
 }
 ```
 
+### Cross-cloud resource map
+
+| Resource | AWS | Azure | GCP |
+|----------|-----|-------|-----|
+| Network | `aws_vpc` | `azurerm_virtual_network` | `google_compute_network` |
+| Subnet | `aws_subnet` | `azurerm_subnet` | `google_compute_subnetwork` |
+| Compute instance | `aws_instance` | `azurerm_linux_virtual_machine` | `google_compute_instance` |
+| Managed relational DB | `aws_db_instance` / `aws_rds_cluster` | `azurerm_*_flexible_server` | `google_sql_database_instance` |
+| Object storage | `aws_s3_bucket` | `azurerm_storage_account` + `azurerm_storage_container` | `google_storage_bucket` |
+
 ### 5. Composition Layer: Environment-Specific Values Only
 
 **Pattern:** Compositions provide concrete values, modules provide abstractions

--- a/skills/terraform-skill/references/security-compliance.md
+++ b/skills/terraform-skill/references/security-compliance.md
@@ -580,6 +580,17 @@ resource "aws_iam_policy" "bad_policy" {
 
 ---
 
+### Cross-cloud security map
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Secret manager | `aws_secretsmanager_secret` | `azurerm_key_vault_secret` | `google_secret_manager_secret` |
+| Network firewalling | `aws_security_group` + `aws_vpc_security_group_*_rule` | `azurerm_network_security_group` + `azurerm_network_security_rule` | `google_compute_firewall` |
+| Identity | IAM (`aws_iam_role` / `aws_iam_policy`) | RBAC (`azurerm_role_assignment`) | IAM (`google_project_iam_*`) |
+| Encryption at rest | explicit (SSE / KMS) | default-on (optional CMK) | default-on (optional CMEK) |
+
+---
+
 ## Compliance Checklists
 
 ### SOC 2 Compliance

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -37,6 +37,34 @@ This document provides detailed guidance on state management, from remote backen
 - ✅ Team collaboration
 - ✅ Audit logging
 
+### Choosing a Remote Backend
+
+| Backend | Use when |
+|---------|----------|
+| `s3` | AWS workloads, existing AWS state |
+| `azurerm` | Azure workloads |
+| `gcs` | GCP workloads |
+| `cloud` / TF Cloud / HCP | hosted state, run management, policy enforcement |
+
+Locking mechanism per backend: see [Backend Locking Support](#backend-locking-support) below.
+
+### Cross-cloud equivalents
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Backend block | `backend "s3" { bucket, key, region, encrypt, use_lockfile }` | `backend "azurerm" { resource_group_name, storage_account_name, container_name, key }` | `backend "gcs" { bucket, prefix }` |
+| Access control | IAM policy on bucket/role | RBAC role assignment on storage account/container | IAM binding on the bucket |
+| Remote-state data source | `terraform_remote_state` (backend `s3`) | `terraform_remote_state` (backend `azurerm`) | `terraform_remote_state` (backend `gcs`) |
+
+### Bootstrap parity
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Versioning | S3 bucket versioning | storage account / blob versioning | GCS object versioning |
+| Encryption at rest | explicit: SSE / KMS (`aws_s3_bucket_server_side_encryption_configuration`) | default-on (SSE; optional CMK) | default-on (Google-managed; optional CMEK) |
+| Public-access block | `aws_s3_bucket_public_access_block` | `allow_nested_items_to_be_public = false` + private container | uniform bucket-level access + public access prevention |
+| Bootstrap auth | IAM / OIDC | RBAC / federated credentials | IAM / Workload Identity Federation |
+
 ### AWS S3 Backend (Recommended)
 
 #### S3 with Native Lock-File (Terraform 1.10+, Recommended)

--- a/skills/terraform-skill/references/testing-frameworks.md
+++ b/skills/terraform-skill/references/testing-frameworks.md
@@ -106,6 +106,8 @@ run "verify_encryption" {
 }
 ```
 
+> Pattern applies identically on Azure/GCP; only provider/resource names change. See [Module Patterns: Cross-cloud resource map](module-patterns.md#cross-cloud-resource-map).
+
 ### Critical: Validate Resource Schemas First
 
 **Always use Terraform MCP to validate resource schemas before writing tests:**

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -252,7 +252,7 @@ I'm starting a new Terraform project. How should I set up state management?
 - Recommends remote backend with security features:
   - Encryption at rest (S3 bucket encryption)
   - Encryption in transit (HTTPS endpoints)
-  - State locking (DynamoDB for S3, etc.)
+  - State locking (S3 `use_lockfile`; DynamoDB legacy)
   - Access controls (IAM policies)
   - Versioning enabled
 - References Security & Compliance guide
@@ -729,6 +729,6 @@ Format per scenario: terse user prompt, the specific hallucination, expected cor
 - Shell-out to `aws ssm send-command` via `local-exec` instead of declarative alternatives
 - No mention of idempotency or re-run semantics
 
-**Target guard:** to be added in `references/code-patterns.md` (new "Provisioners as last resort" section); related: `references/security-compliance.md` LLM checklist line 548 (secrets via local-exec)
+**Target guard:** `references/code-patterns.md#provisioners-as-last-resort`; related: `references/security-compliance.md` LLM checklist (secrets via local-exec)
 
 ---

--- a/tests/baseline-scenarios.md
+++ b/tests/baseline-scenarios.md
@@ -451,7 +451,7 @@ Each rationalization gets an explicit counter added to SKILL.md.
 ### Success Metrics
 
 For skill to be considered "passing TDD":
-- [ ] **9/9 scenarios** show clear behavior change WITH skill vs baseline
+- [ ] **11/11 scenarios** show clear behavior change WITH skill vs baseline
 - [ ] Agent uses skill content (decision matrices, patterns, checklists)
 - [ ] Agent doesn't rationalize skipping best practices
 - [ ] Rationalizations documented and countered in skill
@@ -467,10 +467,12 @@ For skill to be considered "passing TDD":
 7. **Minimal module structure** (Scenario 7)
 8. **Bare-bones variables** (Scenario 8)
 9. **Navigation / safe-rename blind spots** (Scenario 17)
+10. **Azure remote state defaulting to S3** (Scenario 18)
+11. **GCP module emitting AWS resources** (Scenario 19)
 
 ### RED Phase Complete When:
 
-- [ ] All 9 scenarios run WITHOUT skill
+- [ ] All 11 scenarios run WITHOUT skill
 - [ ] Results documented in `baseline-results/` directory
 - [ ] Rationalizations captured verbatim
 - [ ] Comparison criteria defined for GREEN phase
@@ -485,6 +487,68 @@ After completing RED phase:
 3. → Iterate: Find new loopholes, plug them, re-test
 
 **Remember:** This is TDD for documentation. Same rigor as code testing.
+
+---
+
+## Scenario 18: Azure Remote State Defaulting to AWS
+
+**Objective:** Verify the skill returns an `azurerm` backend (not S3) for an Azure project.
+
+### Test Prompt
+```
+Set up remote state for our Azure project.
+```
+
+### Expected Baseline Behavior (WITHOUT skill)
+- Defaults to an S3 backend or generic example, ignoring the Azure context.
+- **Rationalization:** "Here is the standard backend configuration" (shows `backend "s3"`)
+
+### Target Behavior (WITH skill)
+- Returns `backend "azurerm"` with resource group / storage account / container / key.
+- Notes that Azure blob-lease locking is automatic (no separate lock table needed).
+
+### Pressure Variations
+- **"Just give me the standard backend."** - must still return `azurerm`, not S3.
+- **"We already use S3 elsewhere."** - must not cross-default the Azure project to S3.
+
+### Forbidden Signals
+- `backend "s3"`, `use_lockfile`, `dynamodb_table` appearing in the Azure answer.
+
+### Success Criteria
+- [ ] Names the `azurerm` backend with correct required arguments (resource_group_name, storage_account_name, container_name, key)
+- [ ] Does not emit any S3 / DynamoDB arguments
+- [ ] Notes that blob-lease locking is built in (no extra resource needed)
+
+---
+
+## Scenario 19: GCP Module Defaulting to AWS Resources
+
+**Objective:** Verify the skill uses `google_*` resources (not `aws_*`) for a GCP module.
+
+### Test Prompt
+```
+Write a module for a network and a compute instance on GCP.
+```
+
+### Expected Baseline Behavior (WITHOUT skill)
+- Emits `aws_vpc` / `aws_instance` or a generic AWS example.
+- **Rationalization:** "Here is a standard network + instance module" (shows AWS resources)
+
+### Target Behavior (WITH skill)
+- Uses `google_compute_network` / `google_compute_subnetwork` / `google_compute_instance`.
+- For state backend, points at the `gcs` backend (not S3).
+
+### Pressure Variations
+- **"Use the usual resources."** - must resolve to GCP-native resources.
+- **"Same as our AWS module."** - must translate to `google_*`, not copy `aws_*`.
+
+### Forbidden Signals
+- `aws_vpc`, `aws_instance`, `aws_subnet` appearing in the GCP answer.
+
+### Success Criteria
+- [ ] All resources use the `google_*` provider namespace
+- [ ] Backend guidance references `gcs`, not `s3`
+- [ ] No `aws_*` resources appear in the output
 
 ---
 

--- a/tests/compliance-verification.md
+++ b/tests/compliance-verification.md
@@ -274,9 +274,9 @@ Look for agent:
 Skill is considered "passing GREEN phase" when:
 
 **Quantitative:**
-- [ ] 8/8 scenarios show measurable behavior improvement
+- [ ] All baseline-scenarios.md scenarios show measurable behavior improvement
 - [ ] 80%+ of success criteria met across all scenarios
-- [ ] Agent references skill content in 7/8+ scenarios
+- [ ] Agent references skill content in nearly all scenarios
 
 **Qualitative:**
 - [ ] Agent proactively applies patterns (not reactive)
@@ -321,7 +321,7 @@ Create file: `compliance-results/scenario-N-[name].md`
 Create file: `compliance-results/SUMMARY.md`
 
 **Include:**
-- Overview: N/8 scenarios passed
+- Overview: N of all baseline scenarios passed
 - Success criteria: N% met overall
 - Key improvements observed
 - Remaining gaps
@@ -331,7 +331,7 @@ Create file: `compliance-results/SUMMARY.md`
 
 ## GREEN Phase Complete When:
 
-- [ ] All 8 scenarios run WITH skill loaded
+- [ ] All baseline-scenarios.md scenarios run WITH skill loaded
 - [ ] Results documented in `compliance-results/` directory
 - [ ] Comparison to baseline complete for all scenarios
 - [ ] Success criteria evaluated
@@ -346,6 +346,6 @@ After GREEN phase:
 1. → `rationalization-table.md` - Update with findings
 2. → REFACTOR phase - Add counters to SKILL.md for new rationalizations
 3. → Re-test scenarios that failed or partially passed
-4. → Iterate until 8/8 scenarios pass
+4. → Iterate until all scenarios pass
 
-**This is iterative:** First pass may only get 5/8 scenarios passing. That's expected. The goal is continuous improvement through the RED-GREEN-REFACTOR cycle.
+**This is iterative:** First pass may only get a subset of scenarios passing. That's expected. The goal is continuous improvement through the RED-GREEN-REFACTOR cycle.

--- a/tests/rationalization-table.md
+++ b/tests/rationalization-table.md
@@ -57,11 +57,12 @@ This document has two parts:
 | 15 | `ignore_changes = all` to silence plan noise | §15 Blanket `ignore_changes = all` | `references/code-patterns.md#lifecycle-escape-hatches--narrow-by-default` | ✅ |
 | 16 | `provisioner` / `null_resource` + `local-exec` as first-line bootstrap | §16 `provisioner` / `null_resource` bootstrap | `references/code-patterns.md#provisioners-as-last-resort` | ✅ |
 | 17 | Semantic navigation skipped; value-symbol rename done as blind text replace; unsupported terraform-ls op claimed | §17 Code Navigation and Safe Rename | `SKILL.md` Code Intelligence + `references/code-intelligence-lsp.md#terraform-ls-capability-matrix` | ✅ |
+| 18 | Defaults to AWS S3 backend or `aws_*` resources even when the user specified Azure or GCP | §18 Azure Remote State Defaulting to AWS / §19 GCP Module Defaulting to AWS Resources | `SKILL.md` Diagnose row + `references/state-management.md#cross-cloud-equivalents` + per-reference cross-cloud maps | ✅ |
 
 ### Coverage Summary
 
-- **Total surfaces tracked:** 17
-- **Covered (`✅`):** 17
+- **Total surfaces tracked:** 18
+- **Covered (`✅`):** 18
 - **Partial (`◐`):** 0
 - **Open gaps (`❌`):** 0
 
@@ -461,7 +462,7 @@ Agents are creative. New rationalizations surface over time. Add them to the cov
 
 ### Overall progress
 
-- **Surfaces tracked:** 17
-- **Scenarios exercising each:** 17 (one-to-one in `baseline-scenarios.md`)
-- **Covered:** 17
+- **Surfaces tracked:** 18
+- **Scenarios exercising each:** 11 unique scenarios (row 18 maps scenarios 18 and 19); see `baseline-scenarios.md`
+- **Covered:** 18
 - **Open:** 0

--- a/tests/rationalization-table.md
+++ b/tests/rationalization-table.md
@@ -57,12 +57,13 @@ This document has two parts:
 | 15 | `ignore_changes = all` to silence plan noise | §15 Blanket `ignore_changes = all` | `references/code-patterns.md#lifecycle-escape-hatches--narrow-by-default` | ✅ |
 | 16 | `provisioner` / `null_resource` + `local-exec` as first-line bootstrap | §16 `provisioner` / `null_resource` bootstrap | `references/code-patterns.md#provisioners-as-last-resort` | ✅ |
 | 17 | Semantic navigation skipped; value-symbol rename done as blind text replace; unsupported terraform-ls op claimed | §17 Code Navigation and Safe Rename | `SKILL.md` Code Intelligence + `references/code-intelligence-lsp.md#terraform-ls-capability-matrix` | ✅ |
-| 18 | Defaults to AWS S3 backend or `aws_*` resources even when the user specified Azure or GCP | §18 Azure Remote State Defaulting to AWS / §19 GCP Module Defaulting to AWS Resources | `SKILL.md` Diagnose row + `references/state-management.md#cross-cloud-equivalents` + per-reference cross-cloud maps | ✅ |
+| 18 | Defaults to AWS S3 backend even when the user specified Azure or GCP | §18 Azure Remote State Defaulting to AWS | `SKILL.md` Diagnose row + `references/state-management.md#cross-cloud-equivalents` | ✅ |
+| 19 | Defaults to `aws_*` resources even when the user specified Azure or GCP | §19 GCP Module Defaulting to AWS Resources | `references/module-patterns.md#cross-cloud-resource-map` + per-reference cross-cloud maps | ✅ |
 
 ### Coverage Summary
 
-- **Total surfaces tracked:** 18
-- **Covered (`✅`):** 18
+- **Total surfaces tracked:** 19
+- **Covered (`✅`):** 19
 - **Partial (`◐`):** 0
 - **Open gaps (`❌`):** 0
 
@@ -462,7 +463,7 @@ Agents are creative. New rationalizations surface over time. Add them to the cov
 
 ### Overall progress
 
-- **Surfaces tracked:** 18
-- **Scenarios exercising each:** 11 unique scenarios (row 18 maps scenarios 18 and 19); see `baseline-scenarios.md`
-- **Covered:** 18
+- **Surfaces tracked:** 19
+- **Scenarios exercising each:** 11 unique scenarios (rows 18 and 19); see `baseline-scenarios.md`
+- **Covered:** 19
 - **Open:** 0


### PR DESCRIPTION
## Summary

Gives AWS / Azure / GCP equal footing in the skill without tripling tokens. Keeps AWS snippets canonical (near-zero AWS regression), adds compact `AWS | Azure | GCP` equivalence tables, and a single on-demand cross-cloud route (progressive disclosure).

## Changes

- **SKILL.md**: renamed `Minimum Viable Backend (AWS S3)` -> `Choosing a Remote Backend`, labeled the S3 block "AWS example", added a `Cross-cloud / provider mapping` diagnose row + route, generalized the Security "Do" line to name AWS Secrets Manager / Azure Key Vault / GCP Secret Manager. (302 -> 305 lines; gate is 500.)
- **state-management.md** (single home for cross-cloud depth): 3 disjoint tables - `Choosing a Remote Backend` (links to the existing `Backend Locking Support` table, no duplication), `Cross-cloud equivalents` (backend block / access control / remote-state data source), `Bootstrap parity` (versioning / encryption / public-access / auth).
- **module-patterns.md**: `Cross-cloud resource map` (engine-neutral DB families).
- **security-compliance.md**: `Cross-cloud security map` (secret manager / firewalling / identity / encryption).
- **ci-cd-workflows.md** (only intended AWS deltas): OIDC promoted to canonical keyless auth (+ `id-token: write`), removed two static `AWS_ACCESS_KEY_ID` examples, fixed stale `dynamodb_table` -> `use_lockfile` (1.10+).
- **code-patterns.md / testing-frameworks.md**: one-line cross-ref notes to the resource map.

## Tests

- `tests/baseline-scenarios.md`: Scenario 18 (Azure backend defaulting to AWS) + Scenario 19 (GCP module defaulting to AWS resources), each with Forbidden Signals.
- `tests/rationalization-table.md`: new surface row "defaults to AWS/S3 when user said Azure/GCP" + guard.
- `tests/compliance-verification.md`: de-hardcoded the scenario counter (was stuck at "8", already omitted scenario 17) to defer to baseline-scenarios.md.

## Verification

- `wc -l SKILL.md` = 305 (< 500 warn); frontmatter OK; broken-link scan clean; all 6 new/linked anchors resolve.
- AWS source-diff regression gate: only SKILL.md + ci-cd-workflows.md touch AWS; all other files are pure additions.
- [ ] Manual behavioral spot-check pending (reload skill, run: GCP remote state -> `gcs`; Azure DB secrets -> Key Vault; S3 state -> unchanged).

## Notes

- One intended AWS deviation from "identical answer": the ci-cd staleness fixes (use_lockfile, OIDC-canonical). Every other AWS snippet unchanged.