### PR TITLE
ci: PR-based release flow (required-check compatible)

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,5 +1,22 @@
 name: Automated Release
 
+# PR-based release flow.
+#
+# Why: master has a ruleset requiring the "Validate Skill Files" status check.
+# A direct push of the release commit (the old flow) is rejected, and the
+# github-actions[bot] cannot be a ruleset bypass actor on a user-owned repo.
+# So the version bump goes through a PR whose required check actually runs.
+#
+# REQUIRES (one-time manual setup):
+#   1. Repo secret RELEASE_TOKEN = fine-grained PAT for this repo with
+#      contents:write + pull-requests:write. The default GITHUB_TOKEN will NOT
+#      work: PRs/branches it creates do not trigger workflows, so the required
+#      "Validate Skill Files" check would never run and auto-merge would hang.
+#   2. Repo Settings -> "Allow auto-merge" enabled (for `gh pr merge --auto`).
+#
+# This workflow (A) opens/refreshes the release PR. tag-release.yml (B) tags +
+# publishes after the PR merges to master.
+
 on:
   push:
     branches:
@@ -8,79 +25,73 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Automated Release
+  release-pr:
+    name: Open release PR
     runs-on: ubuntu-latest
-
+    # Loop guard: do not re-release the merged release commit.
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     steps:
-      # 1. Checkout with full history for conventional commits analysis
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
-      # 2. Bump version, generate changelog, tag, and commit
-      # This action handles:
-      # - Version calculation from conventional commits
-      # - CHANGELOG.md generation and update
-      # - Git tagging
-      # - Git commit and push
-      - name: Conventional Changelog Action
+      - name: Reset release branch
+        run: |
+          git push origin --delete release/next 2>/dev/null || true
+          git checkout -B release/next
+
+      # Version calc + CHANGELOG + version.json + pre-commit sync
+      # (SKILL.md frontmatter metadata.version + .codex-plugin/plugin.json),
+      # committed onto release/next. No tag here (tag is created after merge by
+      # tag-release.yml). skip-ci MUST be false so the PR runs the required check.
+      - name: Conventional Changelog (release branch)
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.RELEASE_TOKEN }}
           git-message: 'chore(release): {version}'
           git-user-name: 'github-actions[bot]'
           git-user-email: 'github-actions[bot]@users.noreply.github.com'
+          git-branch: 'release/next'
           preset: 'angular'
           tag-prefix: 'v'
           output-file: 'CHANGELOG.md'
           version-file: './version.json'
           version-path: 'version'
-          skip-on-empty: 'false'
+          skip-on-empty: 'true'
           skip-version-file: 'false'
           skip-commit: 'false'
-          skip-ci: 'true'
-          # Sync SKILL.md + .codex-plugin/plugin.json BEFORE the action's
-          # commit/tag so tag-pinned consumers get a matching tree. Replaces
-          # the old post-tag amend + force-push.
+          skip-tag: 'true'
+          skip-ci: 'false'
           pre-commit: '.github/release/pre-commit.js'
 
-      # 3. Create GitHub Release
-      # Only run if a new version was created
-      - name: Create GitHub Release
-        if: steps.changelog.outputs.skipped == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          name: ${{ steps.changelog.outputs.tag }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
-          draft: false
-          prerelease: false
+      - name: Open / refresh release PR and enable auto-merge
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 4. Summary
-      - name: Release Summary
-        if: steps.changelog.outputs.skipped == 'false'
-        env:
-          VERSION: ${{ steps.changelog.outputs.version }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           TAG: ${{ steps.changelog.outputs.tag }}
-          CLEAN_CHANGELOG: ${{ steps.changelog.outputs.clean_changelog }}
-          REPOSITORY: ${{ github.repository }}
         run: |
-          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Tag:** $TAG" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Release:** https://github.com/$REPOSITORY/releases/tag/$TAG" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Changelog" >> $GITHUB_STEP_SUMMARY
-          echo "$CLEAN_CHANGELOG" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          # Branch was reset+pushed by the changelog action. Open a PR if none
+          # is open for release/next; otherwise reuse it. Title drives the
+          # squash-merge commit subject so the loop guard (Workflow A) skips it
+          # and Workflow B's trigger matches it.
+          if gh pr view release/next --json number >/dev/null 2>&1; then
+            gh pr edit release/next --title "chore(release): ${TAG}"
+          else
+            gh pr create \
+              --base master \
+              --head release/next \
+              --title "chore(release): ${TAG}" \
+              --body "Automated release ${TAG}. Squash-merging publishes the tag and GitHub Release (tag-release.yml)."
+          fi
+          gh pr merge release/next --auto --squash --subject "chore(release): ${TAG}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,93 @@
+name: Tag and Publish Release
+
+# Part B of the PR-based release flow (see automated-release.yml).
+# Runs after the `chore(release): vX.Y.Z` PR squash-merges to master. It tags
+# the merged master commit and publishes the GitHub Release. It never commits,
+# so it cannot start a release loop.
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag-release:
+    name: Tag and publish
+    runs-on: ubuntu-latest
+    # Only act on the merged release commit.
+    if: ${{ startsWith(github.event.head_commit.message, 'chore(release):') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Resolve version and tag
+        id: ver
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r '.version' version.json)"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::version.json has no version"; exit 1
+          fi
+          TAG="v${VERSION}"
+          # Guard: commit subject must reference this version (catches a desync
+          # between version.json and the release commit).
+          SUBJECT="$(git log -1 --pretty=%s)"
+          case "$SUBJECT" in
+            *"$TAG"*) : ;;
+            *) echo "::error::release commit subject '$SUBJECT' does not match $TAG"; exit 1 ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag (idempotent)
+        id: tag
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            EXISTING="$(git rev-list -n1 "${TAG}")"
+            if [ "$EXISTING" != "$GITHUB_SHA" ]; then
+              echo "::error::tag ${TAG} already exists at ${EXISTING}, not ${GITHUB_SHA}"; exit 1
+            fi
+            echo "Tag ${TAG} already at ${GITHUB_SHA}; skipping create."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            git tag "${TAG}" "${GITHUB_SHA}"
+            git push origin "refs/tags/${TAG}"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog section
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # First version block in CHANGELOG.md (angular preset headings start
+          # with '#' then a bracketed/plain version). Empty file is fine.
+          awk '
+            /^#+[[:space:]]+\[?[0-9]+\./ { if (seen++) exit }
+            seen { print }
+          ' CHANGELOG.md > /tmp/notes.md || true
+          if [ ! -s /tmp/notes.md ]; then echo "Release ${VERSION}" > /tmp/notes.md; fi
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: ${{ steps.ver.outputs.tag }}
+          body_path: /tmp/notes.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Why

`master` now has a ruleset requiring the **Validate Skill Files** check. The old release direct-pushed the `chore(release)` commit to master, which the rule rejects - and `github-actions[bot]` cannot be a ruleset bypass actor on a user-owned repo. This reworks releases to go through a PR whose required check actually runs.

Design converged via `/consensus` (GPT + Gemini + Claude, 3 rounds).

## What

- **automated-release.yml** (push→master): skips `chore(release):` commits (loop guard); on a fresh `release/next` branch runs conventional-changelog (version.json + CHANGELOG + `pre-commit.js` sync of SKILL.md frontmatter + `.codex-plugin/plugin.json`), `skip-tag`, **`skip-ci:false`**; opens/refreshes a PR via `RELEASE_TOKEN`, title `chore(release): vX.Y.Z`, `--auto --squash`.
- **tag-release.yml** (push→master): only on the merged `chore(release):` commit; tags the merged master SHA and publishes the GitHub Release. Never commits (no loop).

## Required setup BEFORE merging (or releases break)

1. Add repo secret **`RELEASE_TOKEN`** = fine-grained PAT for this repo, `contents:write` + `pull-requests:write`. (The default `GITHUB_TOKEN` won't work - PRs it creates don't trigger the required check.)
2. Repo Settings → enable **Allow auto-merge**.

## Notes

- No ruleset bypass needed: the release is validated by its own PR; tag creation isn't gated by the branch rule.
- Draft until the two setup steps are done. Independent of #33.