### PR TITLE
ci: fix release job (git pull tracking) so Automated Release doesn't fail

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -44,10 +44,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Reset release branch
-        run: |
-          git push origin --delete release/next 2>/dev/null || true
-          git checkout -B release/next
+      # Stay on master (which has upstream tracking) so the action's internal
+      # `git pull --ff-only` works. The changelog action pushes the release
+      # commit to `release/next` via its `git-branch` input. Just clear any
+      # stale release/next first.
+      - name: Delete stale release branch
+        run: git push origin --delete release/next 2>/dev/null || true
 
       # Version calc + CHANGELOG + version.json + pre-commit sync
       # (SKILL.md frontmatter metadata.version + .codex-plugin/plugin.json),
@@ -94,4 +96,4 @@ jobs:
               --title "chore(release): ${TAG}" \
               --body "Automated release ${TAG}. Squash-merging publishes the tag and GitHub Release (tag-release.yml)."
           fi
-          gh pr merge release/next --auto --squash --subject "chore(release): ${TAG}"
+          gh pr merge release/next --auto --squash --delete-branch --subject "chore(release): ${TAG}"


### PR DESCRIPTION
Follow-up to #34. The release job did `git checkout -B release/next` (no upstream), so the changelog action's `git pull --ff-only` failed at setup - Automated Release errored on the #34 merge. Fix: stay on master (has tracking); the action pushes to `release/next` via its `git-branch` input. Adds `--delete-branch` on auto-merge. `ci:` commit, so merging it won't cut a release - it should make Automated Release **skip cleanly** instead of failing.