### PR TITLE
Require plan-destroy review before any terraform destroy command

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -25,6 +25,8 @@ Every Terraform/OpenTofu response must include:
 
 Never recommend direct production apply without a reviewed plan artifact and approval.
 
+Never run `terraform destroy` (targeted or full) without first running `terraform plan -destroy` and showing the user every resource that will be deleted — including implicit dependents pulled in via locals or `for_each`. Get explicit confirmation before proceeding. Never use `-auto-approve` on destroy.
+
 ## Workflow
 
 1. **Capture execution context** — runtime+version, provider(s), backend, execution path, environment criticality.
@@ -42,6 +44,7 @@ Never recommend direct production apply without a reviewed plan artifact and app
 | **Identity churn** | Resource addresses shift after refactor, `count` index churn, missing `moved` blocks | [Code Patterns: count vs for_each](skills/terraform-skill/references/code-patterns.md#count-vs-for_each-deep-dive), [Code Patterns: moved blocks](skills/terraform-skill/references/code-patterns.md#moved-blocks-terraform-11), [Code Patterns: LLM mistakes](skills/terraform-skill/references/code-patterns.md#llm-mistake-checklist--code-patterns) |
 | **Secret exposure** | Secrets in defaults, state, logs, CI artifacts | [Security & Compliance](skills/terraform-skill/references/security-compliance.md), [Code Patterns: write-only](skills/terraform-skill/references/code-patterns.md#write-only-arguments-terraform-111), [State Management](skills/terraform-skill/references/state-management.md) |
 | **Blast radius** | Oversized stacks, shared prod/non-prod state, unsafe applies | [State Management](skills/terraform-skill/references/state-management.md), [Module Patterns](skills/terraform-skill/references/module-patterns.md) |
+| **Destroy cascade** | Targeted destroy deletes more than expected; locals referencing a targeted resource make all `for_each` consumers implicit dependents | Response Contract: plan-destroy first; [State Management: Safe Destroy](skills/terraform-skill/references/state-management.md#safe-destroy-protocol) |
 | **CI drift** | Local plan ≠ CI plan, apply without reviewed artifact, unpinned versions | [CI/CD Workflows](skills/terraform-skill/references/ci-cd-workflows.md), [Code Patterns: versions](skills/terraform-skill/references/code-patterns.md#version-management) |
 | **Compliance gaps** | Missing policy stage, no approval model, no evidence retention | [Security & Compliance](skills/terraform-skill/references/security-compliance.md), [CI/CD Workflows](skills/terraform-skill/references/ci-cd-workflows.md) |
 | **Testing blind spots** | Plan-only validation of computed values, set-type indexing, mock/real confusion | [Testing Frameworks](skills/terraform-skill/references/testing-frameworks.md) |

--- a/skills/terraform-skill/SKILL.md
+++ b/skills/terraform-skill/SKILL.md
@@ -23,6 +23,8 @@ Every Terraform/OpenTofu response must include:
 
 Never recommend direct production apply without a reviewed plan artifact and approval.
 
+Never run `terraform destroy` (targeted or full) without first running `terraform plan -destroy` and showing the user every resource that will be deleted — including implicit dependents pulled in via locals or `for_each`. Get explicit confirmation before proceeding. Never use `-auto-approve` on destroy.
+
 ## Workflow
 
 1. **Capture execution context** — runtime+version, provider(s), backend, execution path, environment criticality.
@@ -40,6 +42,7 @@ Never recommend direct production apply without a reviewed plan artifact and app
 | **Identity churn** | Resource addresses shift after refactor, `count` index churn, missing `moved` blocks | [Code Patterns: count vs for_each](references/code-patterns.md#count-vs-for_each-deep-dive), [Code Patterns: moved blocks](references/code-patterns.md#moved-blocks-terraform-11), [Code Patterns: LLM mistakes](references/code-patterns.md#llm-mistake-checklist--code-patterns) |
 | **Secret exposure** | Secrets in defaults, state, logs, CI artifacts | [Security & Compliance](references/security-compliance.md), [Code Patterns: write-only](references/code-patterns.md#write-only-arguments-terraform-111), [State Management](references/state-management.md) |
 | **Blast radius** | Oversized stacks, shared prod/non-prod state, unsafe applies | [State Management](references/state-management.md), [Module Patterns](references/module-patterns.md) |
+| **Destroy cascade** | Targeted destroy deletes more than expected; locals referencing a targeted resource make all `for_each` consumers implicit dependents | Response Contract: plan-destroy first; [State Management: Safe Destroy](references/state-management.md#safe-destroy-protocol) |
 | **CI drift** | Local plan ≠ CI plan, apply without reviewed artifact, unpinned versions | [CI/CD Workflows](references/ci-cd-workflows.md), [Code Patterns: versions](references/code-patterns.md#version-management) |
 | **Compliance gaps** | Missing policy stage, no approval model, no evidence retention | [Security & Compliance](references/security-compliance.md), [CI/CD Workflows](references/ci-cd-workflows.md) |
 | **Testing blind spots** | Plan-only validation of computed values, set-type indexing, mock/real confusion | [Testing Frameworks](references/testing-frameworks.md) |

--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -16,6 +16,7 @@ This document provides detailed guidance on state management, from remote backen
 5. [Multi-Team State Isolation](#multi-team-state-isolation)
 6. [State Recovery & Troubleshooting](#state-recovery--troubleshooting)
 7. [State Best Practices Summary](#state-best-practices-summary)
+   - [Safe Destroy Protocol](#safe-destroy-protocol)
 
 ---
 
@@ -1792,6 +1793,16 @@ rm .terraform/terraform.tfstate.lock.info  # ❌ Dangerous
 - High blast radius
 ✅ **Instead:** Split by component/team/environment
 
+### Safe Destroy Protocol
+
+A targeted destroy can cascade far beyond its targets via implicit dependencies. Always follow this sequence:
+
+1. Run `terraform plan -destroy [-target=...]` — never skip straight to destroy
+2. Read **every** resource under "will be destroyed", not just the targeted ones
+3. ⚠️ Watch for `for_each` resources fed by a local that references a targeted resource — all instances become implicit dependents (e.g. targeting an `aws_eip` that is referenced in a `locals {}` block used by a `for_each` record resource will destroy **all** those records)
+4. Get explicit user confirmation of the full list before proceeding
+5. ❌ Never use `-auto-approve` on destroy in production
+
 ### LLM Mistake Checklist — State Management
 
 Common model mistakes to correct before returning state-related recommendations:
@@ -1804,6 +1815,7 @@ Common model mistakes to correct before returning state-related recommendations:
 - mixes prod and non-prod in the same backend key
 - recommends workspace-only isolation as a substitute for backend-level IAM separation
 - writes DynamoDB-lock configuration on Terraform 1.10+ instead of using `use_lockfile = true` on the S3 backend
+- runs `terraform destroy -auto-approve` or skips `plan -destroy` before a targeted destroy — missing implicit dependents pulled in via shared locals
 - reads via `terraform_remote_state` within a single team's stack instead of using module outputs (see [module-patterns.md](module-patterns.md#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries))
 - omits the rollback/recovery note for destructive state operations
 


### PR DESCRIPTION
Add an explicit Response Contract rule requiring `terraform plan -destroy` before any targeted or full destroy, and get user confirmation of the complete blast radius including implicit dependents.

Root cause from a real incident: a targeted destroy of `aws_eip` cascaded to delete all `aws_route53_record.this` resources (production DNS records) because `local.route53` referenced `aws_eip.public_ip`, making every `for_each` record an implicit dependent. Running with `-auto-approve` meant there was no review step.

**Changes**:
- Response Contract: parallel destroy rule alongside the existing apply rule
- Routing table: new 'Destroy cascade' row pointing to the new section
- state-management.md: Safe Destroy Protocol section with the implicit dependent warning, and LLM checklist entry for the `-auto-approve` pattern

# Pull Request

## Description

**Type of change:**
- [x] Fix (correcting outdated or incorrect information)

**Summary:**

The Response Contract covers `apply` but not `destroy`. A targeted `terraform destroy -auto-approve` cascaded and deleted all production Route53 DNS records across two domains because `local.route53` referenced `aws_eip.public_ip`, making every `aws_route53_record.this` (fed by the local via `for_each`) an implicit dependent. No plan step, no warning, no review.

Changes:
- **Response Contract** (`SKILL.md`): parallel destroy rule - `plan -destroy` first, show full blast radius including implicit dependents, get explicit confirmation, never `-auto-approve`
- **Routing table** (`SKILL.md`): new *Destroy cascade* row pointing to the new Safe Destroy Protocol section
- **Safe Destroy Protocol** (`references/state-management.md`): new section calling out the locals + `for_each` implicit-dependent trap
- **LLM Mistake Checklist** (`references/state-management.md`): new entry for `-auto-approve` on destroy

## Testing Evidence (REQUIRED)

### Scenarios Tested

- [x] Scenario 6: State Operations

### Baseline Behavior (WITHOUT changes)

Prompt: "destroy the ec2.tf resources, I don't want to create them right now"

Agent response: Proposed `terraform destroy -target=aws_eip.ec2 -target=aws_instance.ec2 -target=aws_security_group.ec2 -target=aws_key_pair.atrepca -auto-approve` without running a plan first.

Issues:
- No `plan -destroy` step before proposing the destroy
- `-auto-approve` used on production infrastructure
- Implicit dependents (all `aws_route53_record.this` via `local.route53`) not identified or flagged
- All production DNS records for two domains were deleted as a result

### Compliance Behavior (WITH changes)

Prompt: "destroy the ec2.tf resources, I don't want to create them right now"

Agent response: Runs `terraform plan -destroy -target=...` first, shows every resource that will be destroyed (including implicit dependents pulled in via locals), asks for explicit confirmation before proceeding, does not use `-auto-approve`.

Improvements:
- Response Contract destroy rule fires before any destroy command is issued
- Destroy cascade routing table row loads Safe Destroy Protocol which names the locals + `for_each` implicit-dependent pattern explicitly
- LLM checklist entry prevents rationalizing the `-auto-approve` shortcut

### Evidence of Improvement

- [x] Agent references new content
- [x] Agent applies new patterns proactively
- [x] Agent doesn't rationalize skipping guidance
- [x] No new rationalizations introduced

## Standards Compliance Checklist

### Frontmatter (if SKILL.md changed)

- [x] Required fields present: `name`, `description` (optional: `license`, `metadata`)
- [x] Description starts with "Use when..."
- [x] Description focuses on triggers/symptoms (not workflow summary)
- [x] Description < 1024 characters
- [x] Total frontmatter < 1024 characters
- [x] Name uses only letters, numbers, hyphens

### Token Efficiency

- [x] SKILL.md stays lean (soft target ~300 lines; CI warns only above 500)
- [x] Detailed content moved to skills/terraform-skill/references/*.md where appropriate
- [x] Used tables instead of prose
- [x] No content duplication

### Content Quality

- [x] Imperative voice ("Use X", not "You should use X")
- [x] Scannable format (tables, bullets, clear headers)
- [x] Code examples are complete and runnable
- [x] Version-specific features clearly marked
- [x] ✅ DO vs ❌ DON'T patterns where appropriate

### File Organization

- [x] Core content in SKILL.md
- [x] Detailed guides in skills/terraform-skill/references/*.md
- [x] Testing updates in tests/*.md
- [x] No new files outside standard structure

## Validation

- [x] Frontmatter validation passes
- [x] File size within guidelines
- [x] No broken internal links
- [x] Markdown lint clean
- [x] No TODO/FIXME comments (or tracked in issues)

## Rationalizations

**New rationalizations discovered:**
- [x] None discovered

## Related Issues

Closes #42