### PR TITLE
ci: enforce conventional PR titles and block direct push to master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -141,5 +141,6 @@ Relates to #
 
 ### Merge Checklist
 
-- [ ] Squash commits with clear commit message
+- [ ] PR **title** is a valid Conventional Commits subject (enforced by the "Validate PR Title" check) - it becomes the squash commit subject that drives the release
+- [ ] Squash-merge only (direct pushes to master are blocked; the squash subject = the PR title)
 - [ ] Release (CHANGELOG, version bump, tag) is automated from conventional commits on master - no manual step

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,59 @@
+name: Lint PR Title
+
+# Enforce Conventional Commits on the PR TITLE.
+#
+# Why the title (not the commits): PRs are squash-merged and the repo's
+# `squash_merge_commit_title` is `PR_TITLE`, so the PR title becomes the commit
+# subject on master. That subject is what `automated-release.yml`
+# (TriPSs/conventional-changelog-action, angular preset) reads to decide the
+# version bump, changelog group, and whether a release is cut. A
+# non-conventional title => no release / wrong bump.
+#
+# This is a required status check on master (ruleset). It must run on EVERY PR,
+# so there is no `paths:` filter. `pull_request_target` (not `pull_request`) so
+# the check also runs - and can post its status - on PRs from forks, the normal
+# contributor path. The action only reads the title from the event payload; it
+# never checks out PR/fork code, so running in the base-repo context is safe.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: pr-title-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint PR title against Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Angular preset types - must match the changelog action so a title
+          # that lints here also produces the intended release behavior.
+          # Breaking changes (`feat!:`, `fix!:`) are handled natively.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,13 @@ Releases are **fully automated** from conventional commits on `master`:
 | `fix:` | Patch |
 | Other | Patch (default) |
 
+`master` is protected by a ruleset: **no direct pushes** (all changes land via
+PR) and two required checks - `Validate Skill Files` and `Validate PR Title`.
+PRs are **squash-merged**, so the **PR title** becomes the master commit
+subject that drives the bump above; `pr-title-lint.yml` enforces that the title
+is a valid conventional subject. The release flow (`automated-release.yml`)
+opens its own `chore(release): vX.Y.Z` PR and auto-merges it.
+
 The release workflow automatically:
 - Bumps the version in `CHANGELOG.md`
 - Syncs `skills/terraform-skill/SKILL.md` YAML frontmatter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,18 @@ git commit -m "chore: update workflow dependencies"
 
 Commit type determines the version bump, the changelog group, and whether a release is cut on merge to master. The release workflow updates the version in SKILL.md frontmatter (the single version source) and tags the release.
 
+### The PR title is what counts
+
+PRs are **squash-merged**, and the squash commit subject is the **PR title**. That title is the subject the release workflow reads on master - so the **PR title must be a valid Conventional Commits subject** (e.g. `feat: add native test mocking guidance`), not just your individual commits.
+
+- ✅ Title the PR with a conventional `type: description` (use `feat!:` or a `BREAKING CHANGE:` footer for breaking changes).
+- A required CI check, **"Validate PR Title"**, lints the title on every PR and blocks merge until it conforms.
+- Your in-progress commit messages are squashed away, so they need not be conventional - only the PR title.
+
+### No direct pushes to master
+
+`master` is protected: **all changes land through a pull request** (direct pushes are rejected). Releases also go through an automated PR - see the Release Process below.
+
 ## Submitting Changes
 
 ### Pull Request Process


### PR DESCRIPTION
## What

- **New workflow `pr-title-lint.yml`** - lints the PR **title** against Conventional Commits using `amannn/action-semantic-pull-request@v5` (job name `Validate PR Title`). Runs on `pull_request_target` for every PR (no `paths:` filter) so it works for fork PRs and never hangs as a required check.
- **Docs** - `CONTRIBUTING.md`, the PR template, and `CLAUDE.md` now state that the PR title must be a valid conventional subject and that `master` only takes changes via PR.

## Why

Releases are cut from the conventional-commit subject on `master`. Because the repo squash-merges with `squash_merge_commit_title = PR_TITLE`, the **PR title** is that subject - but nothing enforced its format, and direct pushes to `master` were only blocked implicitly.

## Applied out-of-band via the GitHub API (not in this diff)

- Repo settings: `allow_merge_commit=false`, `allow_rebase_merge=false`, `delete_branch_on_merge=true` (squash-only).
- Master ruleset `16783810`: added a `pull_request` rule (`required_approving_review_count: 0`, `allowed_merge_methods: ["squash"]`) - **direct pushes to master are now denied**.

## Follow-up (after this merges)

Add `Validate PR Title` to the ruleset's required status checks. It is held until the workflow exists on `master`, otherwise the required check would have no run to satisfy and would block this first PR.

## Release flow

Unaffected: `automated-release.yml` opens a `chore(release): vX.Y.Z` PR (valid conventional title) and auto-merges via squash; `tag-release.yml` pushes only a tag.