### PR TITLE
fix: use ASCII hyphens in Safe Destroy Protocol guidance

### DIFF
--- a/skills/terraform-skill/references/state-management.md
+++ b/skills/terraform-skill/references/state-management.md
@@ -1797,9 +1797,9 @@ rm .terraform/terraform.tfstate.lock.info  # ❌ Dangerous
 
 A targeted destroy can cascade far beyond its targets via implicit dependencies. Always follow this sequence:
 
-1. Run `terraform plan -destroy [-target=...]` — never skip straight to destroy
+1. Run `terraform plan -destroy [-target=...]` - never skip straight to destroy
 2. Read **every** resource under "will be destroyed", not just the targeted ones
-3. ⚠️ Watch for `for_each` resources fed by a local that references a targeted resource — all instances become implicit dependents (e.g. targeting an `aws_eip` that is referenced in a `locals {}` block used by a `for_each` record resource will destroy **all** those records)
+3. ⚠️ Watch for `for_each` resources fed by a local that references a targeted resource - all instances become implicit dependents (e.g. targeting an `aws_eip` that is referenced in a `locals {}` block used by a `for_each` record resource will destroy **all** those records)
 4. Get explicit user confirmation of the full list before proceeding
 5. ❌ Never use `-auto-approve` on destroy in production
 
@@ -1815,7 +1815,7 @@ Common model mistakes to correct before returning state-related recommendations:
 - mixes prod and non-prod in the same backend key
 - recommends workspace-only isolation as a substitute for backend-level IAM separation
 - writes DynamoDB-lock configuration on Terraform 1.10+ instead of using `use_lockfile = true` on the S3 backend
-- runs `terraform destroy -auto-approve` or skips `plan -destroy` before a targeted destroy — missing implicit dependents pulled in via shared locals
+- runs `terraform destroy -auto-approve` or skips `plan -destroy` before a targeted destroy - missing implicit dependents pulled in via shared locals
 - reads via `terraform_remote_state` within a single team's stack instead of using module outputs (see [module-patterns.md](module-patterns.md#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries))
 - omits the rollback/recovery note for destructive state operations
 


### PR DESCRIPTION
## What

Normalize three em dashes (`—`) to ASCII ` - ` in the **Safe Destroy Protocol** prose of `references/state-management.md` (added in #43).

## Why

- The repo's house style is ASCII-only for authored prose; em dashes are a no-go.
- Also cuts the **patch release that #43 never triggered**: #43 merged with a non-conventional title (`Require plan-destroy review...`), so the angular preset bumped nothing. This `fix:` title produces the patch bump that publishes the destroy-guidance work.

## Scope / safety

- References file only - `POWER.md` derives solely from `SKILL.md`, so no regeneration needed.
- Body lines only (1800/1802/1818); the `### LLM Mistake Checklist — State Management` heading is left untouched so the SKILL.md anchor stays stable.