### PR TITLE
ci: run Validate Skill Files on every PR (no path filter)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,15 +1,14 @@
 name: Validate Skill
 
 on:
+  # No `paths:` filter on pull_request: `Validate Skill Files` is a required
+  # status check on master (ruleset), so it MUST run on EVERY PR - otherwise a
+  # PR that touches no filtered path (e.g. README-only) never reports the check
+  # and stays blocked forever. Same rule as pr-title-lint.yml. Validation steps
+  # read files that always exist (SKILL.md, POWER.md, .codex-plugin, mcp.json),
+  # so docs-only PRs pass cleanly. The push trigger keeps its paths filter (see
+  # release-bot interaction) - do not add one back here.
   pull_request:
-    paths:
-      - 'skills/**'
-      - '.claude-plugin/**'
-      - '.codex-plugin/**'
-      - 'POWER.md'
-      - 'mcp.json'
-      - '.github/workflows/**'
-      - '.github/release/**'
   push:
     branches: [master, main]
     paths:


### PR DESCRIPTION
## Problem

`Validate Skill Files` (validate.yml) is a **required** status check on master, but its `pull_request` trigger had a `paths:` filter (`skills/**`, `.codex-plugin/**`, etc.). A PR touching no filtered path - e.g. README-only #47 - never triggers the workflow, so the required check is never reported and GitHub holds the PR at `BLOCKED` / "Expected — waiting for status" forever.

`Validate PR Title` already runs on every PR for exactly this reason; its header comment documents the rule: *"required status check on master. It must run on EVERY PR, so there is no `paths:` filter."* validate.yml violated that rule.

## Fix

Drop the `paths:` filter from the **`pull_request` trigger only**. The validation steps read files that always exist (`SKILL.md`, `POWER.md`, `.codex-plugin/plugin.json`, `mcp.json`), so docs-only PRs pass cleanly. `markdownlint` already globs README.md and is `continue-on-error`.

The `push` trigger keeps its `paths:` filter unchanged (avoids interfering with the `[skip ci]` auto-release flow on master).

## Unblocks

#47 (README-only, currently `BLOCKED`). After this merges, reopen/sync #47 to retrigger its checks against the updated base workflow.

## Verification

- This PR edits `.github/workflows/**`, so `Validate Skill Files` runs here and must pass green.
- Single-block deletion; push paths intact.