### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,29 @@ separate marketplace - it clashes by name with `agent-plugins`.
 </details>
 
 <details>
+<summary>Autohand Code</summary>
+
+Install the skill globally:
+
+```bash
+git clone https://github.com/antonbabenko/terraform-skill.git
+mkdir -p ~/.autohand/skills
+cp -R terraform-skill/skills/terraform-skill ~/.autohand/skills/
+```
+
+Or install it only for the current project:
+
+```bash
+git clone https://github.com/antonbabenko/terraform-skill.git
+mkdir -p .autohand/skills
+cp -R terraform-skill/skills/terraform-skill .autohand/skills/
+```
+
+Autohand Code discovers skills from `~/.autohand/skills/` and `.autohand/skills/`.
+
+</details>
+
+<details>
 <summary>Kiro</summary>
 
 ```bash


### PR DESCRIPTION
## Description

**Type of change:**
- [ ] New content (adding best practices, patterns, or guidance)
- [ ] Fix (correcting outdated or incorrect information)
- [ ] Refactor (reorganizing or improving clarity)
- [x] Documentation (README, CONTRIBUTING, etc.)
- [ ] Testing framework improvement

**Summary:**
Adds an Autohand Code install section beside the existing Claude Code, Gemini CLI, Cursor, Copilot, OpenCode, Codex, Kiro, and Antigravity setup notes.

The new section is intentionally manual/global-or-project only. I did not claim marketplace or catalog support because this repository does not appear in the current public Autohand Skills index.

## Testing Evidence (REQUIRED)

### Scenarios Tested

- [x] N/A - README-only client installation documentation; no Terraform/OpenTofu skill behavior or agent guidance changed.

### Baseline Behavior (WITHOUT changes)

```text
The README included install notes for several compatible agents, but did not describe where Autohand Code users should place the existing skills/terraform-skill package.
```

### Compliance Behavior (WITH changes)

```text
The README now includes Autohand Code global and project-local copy instructions using:
- ~/.autohand/skills/
- .autohand/skills/
```

### Evidence of Improvement

- [x] Autohand Code users can install the existing skill package without changing repository contents or generated manifests.
- [x] No skill behavior guidance changed.
- [x] No new rationalizations introduced.

## Standards Compliance Checklist

### Frontmatter (if SKILL.md changed)

- [x] N/A - SKILL.md was not changed.

### Token Efficiency

- [x] SKILL.md untouched.
- [x] README addition is scoped to one collapsible install section.
- [x] No content duplication outside the existing per-agent install pattern.

### Content Quality

- [x] Scannable format with runnable shell commands.
- [x] Existing install-section structure preserved.

### File Organization

- [x] README-only documentation change.
- [x] No new files outside standard structure.

## Validation

- [x] `git diff --check`
- [x] `node .github/release/build-power.js --check`
- [ ] `npx -y markdownlint-cli2 --config .markdownlint.json README.md CONTRIBUTING.md 'skills/**/*.md'`
  - This currently reports existing repository-wide lint findings, including pre-existing README `<details>` / `<summary>` usage and many existing skill reference formatting issues. I did not broaden this PR into unrelated lint cleanup.

## Rationalizations

**New rationalizations discovered:**
- [x] None discovered

## Related Issues

Relates to Autohand Code skill install documentation.